### PR TITLE
Klondike UIの表記整理とスート/色判定の修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
         <button onclick="location.reload()">Deal Again</button>
     </div>
     
-    <div id="stuck-warning">⚠️ 手詰まりの可能性あり (Undo推奨)</div>
+    <div id="stuck-warning">⚠️ Likely Stuck (Undo Recommended)</div>
 
     <header>
       <h1>Klondike (Solitaire)</h1>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
-    <title>Klondike - Fixed Order</title>
+    <title>Klondike (Solitaire)</title>
     <script src="https://cardmeister.github.io/elements.cardmeister.min.js"></script>
     <style>
       :root {
@@ -82,11 +82,11 @@
     <div id="stuck-warning">⚠️ 手詰まりの可能性あり (Undo推奨)</div>
 
     <header>
-      <h1>Solitaire</h1>
+      <h1>Klondike (Solitaire)</h1>
       <div class="controls">
         <span id="status-msg"></span>
         <label class="toggle-label" title="自動判定＋デバッグログ出力">
-            <input type="checkbox" id="chk-autocheck"> 常時チェック
+            <input type="checkbox" id="chk-autocheck"> Solvability Check
         </label>
         <button id="btn-undo" disabled>Undo</button>
         <button id="btn-restart" disabled>Restart</button>

--- a/index.html
+++ b/index.html
@@ -272,7 +272,7 @@
       
       function pushHistory() {
         if (state) {
-            if (historyStack.length > 50) historyStack.shift(); 
+            if (historyStack.length > 1000) historyStack.shift(); 
             historyStack.push(JSON.stringify(state));
             updateButtons();
         }

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
-    <title>Klondike - Debug Final</title>
+    <title>Klondike - Fixed Order</title>
     <script src="https://cardmeister.github.io/elements.cardmeister.min.js"></script>
     <style>
       :root {
@@ -110,7 +110,8 @@
 
     <script>
       /* --- [Core] Configuration --- */
-      const SUITS = ["spades", "hearts", "diamonds", "clubs"];
+      // 【変更点1】 並び順を スペード(0), ハート(1), クラブ(2), ダイヤ(3) に変更
+      const SUITS = ["spades", "hearts", "clubs", "diamonds"];
       const RANKS = ["ace", "2", "3", "4", "5", "6", "7", "8", "9", "ten", "jack", "queen", "king"];
       
       let state = null;
@@ -143,7 +144,8 @@
 
         createDeck() {
             const d = [];
-            for (let s = 0; s < 4; s++) for (let r = 0; r < 13; r++) d.push({ suit: s, rank: r + 1, color: (s === 0 || s === 3) ? 0 : 1, isOpen: false });
+            // 【変更点2】 色の判定ロジックを変更。偶数(0,2)が黒、奇数(1,3)が赤
+            for (let s = 0; s < 4; s++) for (let r = 0; r < 13; r++) d.push({ suit: s, rank: r + 1, color: (s % 2 === 0) ? 0 : 1, isOpen: false });
             for (let i = d.length - 1; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); [d[i], d[j]] = [d[j], d[i]]; }
             return d;
         }
@@ -254,7 +256,8 @@
         const otherColor = 1 - card.color;
         let count = 0;
         state.foundations.forEach((f, idx) => {
-            const fColor = (idx === 0 || idx === 3) ? 0 : 1;
+            // 【変更点3】 色判定ロジックの修正 (0=S黒, 1=H赤, 2=C黒, 3=D赤)
+            const fColor = (idx % 2 === 0) ? 0 : 1;
             if (fColor === otherColor) {
                 const top = f[f.length - 1];
                 if (top && top.rank >= targetRank) count++;


### PR DESCRIPTION
Klondike UIの表記整理とスート/色判定の修正

- タイトル/ヘッダ/警告文の英語化と名称統一
- スート順序と色判定ロジックを整合させて修正
- Undo履歴の上限を拡大

- index.html タイトルとUI文言を「Klondike (Solitaire)」基準に整理、警告とチェックラベルを英語化
- index.html SUITS順序を spades, hearts, clubs, diamonds に変更し、色判定を s % 2 に合わせて修正
- index.html Undo履歴の最大数を 50 → 1000 に拡大
