### PR TITLE
Mobile layout fit + solvability check tuning

### DIFF
--- a/index-noanime.html
+++ b/index-noanime.html
@@ -8,6 +8,8 @@
     <style>
       :root {
         --card-w: 100px; --card-h: 140px;
+        --board-pad: 24px;
+        --grid-gap: 15px;
         --bg: #008000;
         --accent: #ffffff;
         --ink: #f5f2ea;
@@ -38,15 +40,19 @@
       
       #status-msg { color: #ffff00; font-weight: bold; font-size: 14px; margin-right: 10px; text-shadow: 1px 1px 0 #000; min-width: 80px; text-align: right; }
       
-      .board { padding: 10px 24px 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
-      .top-row, .bottom-row { display: grid; grid-template-columns: repeat(7, var(--card-w)); gap: 15px; justify-content: center; transition: gap 0.3s; }
+      .board { padding: 10px var(--board-pad) 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
+      .top-row, .bottom-row { display: grid; grid-template-columns: repeat(7, var(--card-w)); gap: var(--grid-gap); justify-content: center; transition: gap 0.3s; }
 
       @media (max-width: 800px) {
-        :root { --card-w: 13vw; --card-h: 18.2vw; }
+        :root {
+          --board-pad: 10px;
+          --grid-gap: 4px;
+          --card-w: clamp(34px, calc((100vw - (var(--board-pad) * 2) - (var(--grid-gap) * 6)) / 7), 100px);
+          --card-h: calc(var(--card-w) * 1.4);
+        }
         header { padding: 12px 10px; }
         .controls { width: 100%; }
-        .board { padding: 10px 10px; gap: 20px; }
-        .top-row, .bottom-row { gap: 8px; }
+        .board { padding: 10px var(--board-pad); gap: 20px; }
       }
 
       .slot, .column {

--- a/index-noanime.html
+++ b/index-noanime.html
@@ -193,7 +193,7 @@
             let moves = 0;
             let noProgressLoop = 0;
             const LIMIT = 1000;
-            while (moves < LIMIT && noProgressLoop < 50) {
+            while (moves < LIMIT && noProgressLoop < 200) {
                 let moved = false;
                 for (let i = 0; i < 7; i++) {
                     const col = simState.tableau[i];

--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
             let moves = 0;
             let noProgressLoop = 0;
             const LIMIT = 1000;
-            while (moves < LIMIT && noProgressLoop < 50) {
+            while (moves < LIMIT && noProgressLoop < 200) {
                 let moved = false;
                 for (let i = 0; i < 7; i++) {
                     const col = simState.tableau[i];

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
     <style>
       :root {
         --card-w: 100px; --card-h: 140px;
+        --board-pad: 24px;
+        --grid-gap: 15px;
         --bg: #008000;
         --accent: #ffffff;
         --ink: #f5f2ea;
@@ -39,15 +41,19 @@
       
       #status-msg { color: #ffff00; font-weight: bold; font-size: 14px; margin-right: 10px; text-shadow: 1px 1px 0 #000; min-width: 80px; text-align: right; }
       
-      .board { padding: 10px 24px 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
-      .top-row, .bottom-row { display: grid; grid-template-columns: repeat(7, var(--card-w)); gap: 15px; justify-content: center; transition: gap 0.3s; }
+      .board { padding: 10px var(--board-pad) 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
+      .top-row, .bottom-row { display: grid; grid-template-columns: repeat(7, var(--card-w)); gap: var(--grid-gap); justify-content: center; transition: gap 0.3s; }
 
       @media (max-width: 800px) {
-        :root { --card-w: 13vw; --card-h: 18.2vw; }
+        :root {
+          --board-pad: 10px;
+          --grid-gap: 4px;
+          --card-w: clamp(34px, calc((100vw - (var(--board-pad) * 2) - (var(--grid-gap) * 6)) / 7), 100px);
+          --card-h: calc(var(--card-w) * 1.4);
+        }
         header { padding: 12px 10px; }
         .controls { width: 100%; }
-        .board { padding: 10px 10px; gap: 20px; }
-        .top-row, .bottom-row { gap: 8px; }
+        .board { padding: 10px var(--board-pad); gap: 20px; }
       }
 
       .slot, .column {


### PR DESCRIPTION
スマホ幅で盤面が横にはみ出さないよう、カード幅を画面幅から計算するレスポンシブ調整を追加（左右パディングとギャップを変数化）
Solvability Check の停滞打ち切り回数を 50→200 に変更して判定の粘りを強化
