### PR TITLE
3rd-partyライセンス情報の明確化とフッターの法務系リンク整理

### DIFF
--- a/index-noanime.html
+++ b/index-noanime.html
@@ -47,7 +47,7 @@
       .board { padding: 10px var(--board-pad) 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
       .legal { text-align: center; font-size: 12px; margin: 12px 0 16px; opacity: 0.85; border-top: 1px solid rgba(255,255,255,0.25); padding-top: 8px; display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: nowrap; }
       .legal a { color: var(--accent); text-decoration: underline; margin: 0 6px; vertical-align: middle; }
-      .oss-badge { display: inline-flex; align-items: center; justify-content: center; width: 16px; height: 16px; border-radius: 999px; background: rgba(0,0,0,0.25); border: 1px solid rgba(255,255,255,0.35); font-size: 8px; font-weight: bold; color: var(--accent); margin: 0 6px; }
+      .oss-badge { display: inline-flex; align-items: center; justify-content: center; padding: 2px 8px; border-radius: 999px; background: rgba(0,0,0,0.25); border: 1px solid rgba(255,255,255,0.35); font-size: 10px; font-weight: bold; color: var(--accent); margin: 0 6px; white-space: nowrap; }
       .top-row, .bottom-row { display: grid; grid-template-columns: repeat(7, var(--card-w)); gap: var(--grid-gap); justify-content: center; transition: gap 0.3s; }
 
       @media (max-width: 800px) {
@@ -137,7 +137,7 @@
           <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
         </svg>
       </a>
-      <a class="oss-badge" href="https://github.com/igapyon/klondike/blob/main/THIRD_PARTY_NOTICES.md" target="_blank" rel="noopener" aria-label="OSS Licenses">OSS</a>
+      <a class="oss-badge" href="https://github.com/igapyon/klondike/blob/main/THIRD_PARTY_NOTICES.md" target="_blank" rel="noopener" aria-label="Third-party notices">Third-Party Notices</a>
     </footer>
 
     <script>

--- a/index-noanime.html
+++ b/index-noanime.html
@@ -47,6 +47,7 @@
       .board { padding: 10px var(--board-pad) 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
       .legal { text-align: center; font-size: 12px; margin: 12px 0 16px; opacity: 0.85; border-top: 1px solid rgba(255,255,255,0.25); padding-top: 8px; display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: nowrap; }
       .legal a { color: var(--accent); text-decoration: underline; margin: 0 6px; vertical-align: middle; }
+      .legal a.oss-badge { text-decoration: none; }
       .oss-badge { display: inline-flex; align-items: center; justify-content: center; padding: 2px 8px; border-radius: 999px; background: rgba(0,0,0,0.25); border: 1px solid rgba(255,255,255,0.35); font-size: 10px; font-weight: bold; color: var(--accent); margin: 0 6px; white-space: nowrap; }
       .top-row, .bottom-row { display: grid; grid-template-columns: repeat(7, var(--card-w)); gap: var(--grid-gap); justify-content: center; transition: gap 0.3s; }
 

--- a/index-online.html
+++ b/index-online.html
@@ -48,7 +48,7 @@
       .board { padding: 10px var(--board-pad) 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
       .legal { text-align: center; font-size: 12px; margin: 12px 0 16px; opacity: 0.85; border-top: 1px solid rgba(255,255,255,0.25); padding-top: 8px; display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: nowrap; }
       .legal a { color: var(--accent); text-decoration: underline; margin: 0 6px; vertical-align: middle; }
-      .oss-badge { display: inline-flex; align-items: center; justify-content: center; width: 16px; height: 16px; border-radius: 999px; background: rgba(0,0,0,0.25); border: 1px solid rgba(255,255,255,0.35); font-size: 8px; font-weight: bold; color: var(--accent); margin: 0 6px; }
+      .oss-badge { display: inline-flex; align-items: center; justify-content: center; padding: 2px 8px; border-radius: 999px; background: rgba(0,0,0,0.25); border: 1px solid rgba(255,255,255,0.35); font-size: 10px; font-weight: bold; color: var(--accent); margin: 0 6px; white-space: nowrap; }
       .top-row, .bottom-row { display: grid; grid-template-columns: repeat(7, var(--card-w)); gap: var(--grid-gap); justify-content: center; transition: gap 0.3s; }
 
       @media (max-width: 800px) {
@@ -139,7 +139,7 @@
           <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
         </svg>
       </a>
-      <a class="oss-badge" href="https://github.com/igapyon/klondike/blob/main/THIRD_PARTY_NOTICES.md" target="_blank" rel="noopener" aria-label="OSS Licenses">OSS</a>
+      <a class="oss-badge" href="https://github.com/igapyon/klondike/blob/main/THIRD_PARTY_NOTICES.md" target="_blank" rel="noopener" aria-label="Third-party notices">Third-Party Notices</a>
     </footer>
 
     <script>

--- a/index-online.html
+++ b/index-online.html
@@ -48,6 +48,7 @@
       .board { padding: 10px var(--board-pad) 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
       .legal { text-align: center; font-size: 12px; margin: 12px 0 16px; opacity: 0.85; border-top: 1px solid rgba(255,255,255,0.25); padding-top: 8px; display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: nowrap; }
       .legal a { color: var(--accent); text-decoration: underline; margin: 0 6px; vertical-align: middle; }
+      .legal a.oss-badge { text-decoration: none; }
       .oss-badge { display: inline-flex; align-items: center; justify-content: center; padding: 2px 8px; border-radius: 999px; background: rgba(0,0,0,0.25); border: 1px solid rgba(255,255,255,0.35); font-size: 10px; font-weight: bold; color: var(--accent); margin: 0 6px; white-space: nowrap; }
       .top-row, .bottom-row { display: grid; grid-template-columns: repeat(7, var(--card-w)); gap: var(--grid-gap); justify-content: center; transition: gap 0.3s; }
 

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
       .board { padding: 10px var(--board-pad) 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
       .legal { text-align: center; font-size: 12px; margin: 12px 0 16px; opacity: 0.85; border-top: 1px solid rgba(255,255,255,0.25); padding-top: 8px; display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: nowrap; }
       .legal a { color: var(--accent); text-decoration: underline; margin: 0 6px; vertical-align: middle; }
+      .legal a.oss-badge { text-decoration: none; }
       .oss-badge { display: inline-flex; align-items: center; justify-content: center; padding: 2px 8px; border-radius: 999px; background: rgba(0,0,0,0.25); border: 1px solid rgba(255,255,255,0.35); font-size: 10px; font-weight: bold; color: var(--accent); margin: 0 6px; white-space: nowrap; }
       .top-row, .bottom-row { display: grid; grid-template-columns: repeat(7, var(--card-w)); gap: var(--grid-gap); justify-content: center; transition: gap 0.3s; }
 

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
       .board { padding: 10px var(--board-pad) 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
       .legal { text-align: center; font-size: 12px; margin: 12px 0 16px; opacity: 0.85; border-top: 1px solid rgba(255,255,255,0.25); padding-top: 8px; display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: nowrap; }
       .legal a { color: var(--accent); text-decoration: underline; margin: 0 6px; vertical-align: middle; }
-      .oss-badge { display: inline-flex; align-items: center; justify-content: center; width: 16px; height: 16px; border-radius: 999px; background: rgba(0,0,0,0.25); border: 1px solid rgba(255,255,255,0.35); font-size: 8px; font-weight: bold; color: var(--accent); margin: 0 6px; }
+      .oss-badge { display: inline-flex; align-items: center; justify-content: center; padding: 2px 8px; border-radius: 999px; background: rgba(0,0,0,0.25); border: 1px solid rgba(255,255,255,0.35); font-size: 10px; font-weight: bold; color: var(--accent); margin: 0 6px; white-space: nowrap; }
       .top-row, .bottom-row { display: grid; grid-template-columns: repeat(7, var(--card-w)); gap: var(--grid-gap); justify-content: center; transition: gap 0.3s; }
 
       @media (max-width: 800px) {
@@ -151,7 +151,7 @@
           <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
         </svg>
       </a>
-      <a class="oss-badge" href="https://github.com/igapyon/klondike/blob/main/THIRD_PARTY_NOTICES.md" target="_blank" rel="noopener" aria-label="OSS Licenses">OSS</a>
+      <a class="oss-badge" href="https://github.com/igapyon/klondike/blob/main/THIRD_PARTY_NOTICES.md" target="_blank" rel="noopener" aria-label="Third-party notices">Third-Party Notices</a>
     </footer>
 
     <script>


### PR DESCRIPTION
3rd-partyライセンス情報の明確化とフッターの法務系リンク整理

変更点

- THIRD_PARTY_NOTICES.md を追加（CardMeister / Motion One のライセンス本文）
- フッターに Copyright / GitHub / Third‑Party Notices を追加し、GitHubリンクはヘッダーから移動
- バージョン表記を v20260126 に更新（README.md と index*.html）