### PR TITLE
localStorage 保存/復元を実装し、ストレージ手動チェックとTODO進捗管理を追加

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,20 +65,20 @@
 - Use separate storage keys for offline/online variants; define one-time migration from legacy `index*.html` keys.
 - Add deterministic initial-board reproduction code using `seed + attemptIndex` (e.g. `SEED-000137`).
 - Record/lock the generation contract used for reproduction (`schemaVersion`, PRNG/shuffle behavior, solver thresholds).
-- Document the minimum build specification before implementation (inputs/outputs, 2 build targets, offline boundary rules).
-- Define file naming migration for build pipeline:
-- source: `klondike-src.html`
-- outputs: `klondike.html` (offline), `klondike-online.html` (online)
-- no-animation variant removed from active targets.
+- [DONE] Document the minimum build specification before implementation (inputs/outputs, 2 build targets, offline boundary rules).
+- [DONE] Define file naming migration for build pipeline:
+- [DONE] source: `klondike-src.html`
+- [DONE] outputs: `klondike.html` (offline), `klondike-online.html` (online)
+- [DONE] no-animation variant removed from active targets.
 - Define build input/output paths (editable sources under `src/`, generated artifacts under project root or `dist/`).
-- Define target matrix and differences (2 targets):
-- `klondike.html`: offline self-contained (no CDN at runtime).
-- `klondike-online.html`: online target that may keep CDN loading.
+- [DONE] Define target matrix and differences (2 targets):
+- [DONE] `klondike.html`: offline self-contained (no CDN at runtime).
+- [DONE] `klondike-online.html`: online target that may keep CDN loading.
 - Define external dependency boundary rules:
 - offline targets must fail build if any external runtime URL remains.
 - online target must explicitly whitelist allowed CDN URLs.
 - Define deterministic build behavior (same input => same output bytes except timestamp/version fields).
-- Define build command contract (`npm run build`, optional per-target build commands).
+- [DONE] Define build command contract (`npm run build`, optional per-target build commands).
 - Define validation gate command (`npm run check:all`) including at least smoke tests + build.
 - Define migration rule: generated HTML is not edited directly; changes are made in source files and rebuilt.
 - Introduce a mobile-first hamburger menu (`☰`) at top-right for low-frequency actions.
@@ -183,20 +183,20 @@
 - オフライン版/オンライン版で保存キーを分離し、旧 `index*.html` キーからの1回移行方針を定義する。
 - `seed + attemptIndex`（例: `SEED-000137`）で初期盤面を決定的に再現できるコード方式を追加する。
 - 再現性の前提となる生成契約（`schemaVersion`、PRNG/シャッフル挙動、ソルバ閾値）を記録・固定する。
-- 実装前に最小ビルド仕様（入出力、2ターゲット、オフライン境界ルール）を文書化する。
-- ビルド命名の移行方針を定義する。
-- ソース: `klondike-src.html`
-- 出力: `klondike.html`（オフライン）/ `klondike-online.html`（オンライン）
-- noanime 系は現行ターゲットから除外済み（削除済み）。
+- [DONE] 実装前に最小ビルド仕様（入出力、2ターゲット、オフライン境界ルール）を文書化する。
+- [DONE] ビルド命名の移行方針を定義する。
+- [DONE] ソース: `klondike-src.html`
+- [DONE] 出力: `klondike.html`（オフライン）/ `klondike-online.html`（オンライン）
+- [DONE] noanime 系は現行ターゲットから除外済み（削除済み）。
 - ビルドの入出力パスを定義する（編集対象は `src/`、生成物はプロジェクトルートまたは `dist/`）。
-- 2ターゲットの差分方針を定義する。
-- `klondike.html`: オフライン完結（実行時 CDN 禁止）。
-- `klondike-online.html`: オンライン版として CDN 読み込みを許可。
+- [DONE] 2ターゲットの差分方針を定義する。
+- [DONE] `klondike.html`: オフライン完結（実行時 CDN 禁止）。
+- [DONE] `klondike-online.html`: オンライン版として CDN 読み込みを許可。
 - 外部依存の境界ルールを定義する。
 - オフライン版は外部 URL が残っていたらビルド失敗にする。
 - オンライン版は許可 CDN を明示したホワイトリスト運用にする。
 - 決定的ビルド要件を定義する（同一入力から同一出力を生成。時刻/バージョン埋込を除く）。
-- ビルドコマンド仕様を定義する（`npm run build`、必要ならターゲット別コマンド）。
+- [DONE] ビルドコマンド仕様を定義する（`npm run build`、必要ならターゲット別コマンド）。
 - 品質ゲートを定義する（`npm run check:all` に最低限 smoke test + build を含める）。
 - 運用ルールを定義する（生成 HTML を直接編集しない。変更はソースを編集して再ビルドする）。
 - スマホ向けに右上ハンバーガーメニュー（`☰`）を導入し、低頻度操作の退避先にする。

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Play Klondike (Solitaire) in the browser — a single-file, easy-to-share web ap
 - Run `npm run build`.
 - This generates `klondike.html` and `klondike-online.html` from `klondike-src.html`.
 
+## Manual Checklist (Storage)
+- Start `klondike.html`, make a manual move, reload, and confirm the board is restored.
+- Confirm save triggers work after: manual move, `New Game`, `Restart`, `Undo`.
+- Confirm no new save is created by actions outside the current scope (for example: auto-chain only progression).
+- Corrupt the saved JSON in DevTools (`localStorage`) and reload; confirm safe reset (no crash, starts new game).
+- Verify offline/online key split:
+  - Save in `klondike.html`, then open `klondike-online.html` and confirm it does not overwrite/share unexpectedly.
+  - Save in `klondike-online.html`, then return to `klondike.html` and confirm each variant restores its own data.
+- (Optional) If legacy keys exist from `index*.html`, confirm one-time migration into new variant keys.
+
 ## Third-Party
 - This project bundles and/or uses third-party products.
 - See `THIRD_PARTY_NOTICES.md` for license texts and attributions.
@@ -63,6 +73,16 @@ Play Klondike (Solitaire) in the browser — a single-file, easy-to-share web ap
 ## ビルド
 - `npm run build` を実行します。
 - `klondike-src.html` から `klondike.html` と `klondike-online.html` を生成します。
+
+## 手動チェックリスト（ストレージ）
+- `klondike.html` を開いて手動操作を1回行い、リロード後に盤面が復元されることを確認する。
+- 保存トリガーが次の操作完了時に動くことを確認する: 手動移動 / `New Game` / `Restart` / `Undo`。
+- 現在スコープ外の操作（例: 自動連鎖のみ進行）で不要な保存が増えないことを確認する。
+- DevTools の `localStorage` で保存JSONを破損させてリロードし、安全リセット（クラッシュせず新規開始）されることを確認する。
+- offline/online のキー分離を確認する:
+  - `klondike.html` 側で保存後、`klondike-online.html` を開いて意図せず上書き/共有されないこと。
+  - `klondike-online.html` 側で保存後、`klondike.html` に戻って各バリアントが自分のデータを復元すること。
+- （任意）旧 `index*.html` キーが残っている場合、新キーへ1回移行されることを確認する。
 
 ## サードパーティ
 - 本プロジェクトはサードパーティ製品を同梱または利用しています。

--- a/klondike-online.html
+++ b/klondike-online.html
@@ -186,6 +186,187 @@
 
       document.getElementById("app-version").textContent = `${Config.APP_VERSION}`;
 
+      /* --- [Persistence] --- */
+      const Persistence = (() => {
+        const SCHEMA_VERSION = 1;
+        const KEY_PREFIX = "klondike:save";
+
+        function getVariant() {
+          const name = (location.pathname.split("/").pop() || "").toLowerCase();
+          return name.includes("online") ? "online" : "offline";
+        }
+
+        function getPrimaryKey() {
+          return `${KEY_PREFIX}:${getVariant()}:v${SCHEMA_VERSION}`;
+        }
+
+        function getLegacyKeys() {
+          const variant = getVariant();
+          const common = ["klondike:save", "klondike-save"];
+          if (variant === "online") {
+            return [
+              ...common,
+              "klondike:save:index-online.html",
+              "klondike-save:index-online.html",
+              "klondike-save-online"
+            ];
+          }
+          return [
+            ...common,
+            "klondike:save:index.html",
+            "klondike:save:index-noanime.html",
+            "klondike-save:index.html",
+            "klondike-save:index-noanime.html",
+            "klondike-save-offline"
+          ];
+        }
+
+        function storageAvailable() {
+          try {
+            const key = "__klondike_storage_test__";
+            localStorage.setItem(key, "1");
+            localStorage.removeItem(key);
+            return true;
+          } catch (e) {
+            return false;
+          }
+        }
+
+        function removeKey(key) {
+          try { localStorage.removeItem(key); } catch (e) {}
+        }
+
+        function migrateLegacyIfNeeded(primaryKey) {
+          let exists = null;
+          try { exists = localStorage.getItem(primaryKey); } catch (e) { return; }
+          if (exists !== null) return;
+          const keys = getLegacyKeys();
+          for (const legacyKey of keys) {
+            let value = null;
+            try { value = localStorage.getItem(legacyKey); } catch (e) { return; }
+            if (value === null) continue;
+            try {
+              localStorage.setItem(primaryKey, value);
+              localStorage.removeItem(legacyKey);
+            } catch (e) {}
+            break;
+          }
+        }
+
+        function isCard(card) {
+          return !!card
+            && Number.isInteger(card.suit) && card.suit >= 0 && card.suit <= 3
+            && Number.isInteger(card.rank) && card.rank >= 1 && card.rank <= 13
+            && Number.isInteger(card.color) && (card.color === 0 || card.color === 1)
+            && typeof card.isOpen === "boolean";
+        }
+
+        function isCardArray(cards) {
+          return Array.isArray(cards) && cards.every(isCard);
+        }
+
+        function isBoardState(state) {
+          if (!state || typeof state !== "object") return false;
+          if (!isCardArray(state.stock) || !isCardArray(state.waste)) return false;
+          if (!Array.isArray(state.foundations) || state.foundations.length !== 4) return false;
+          if (!Array.isArray(state.tableau) || state.tableau.length !== 7) return false;
+          if (!state.foundations.every(isCardArray)) return false;
+          if (!state.tableau.every(isCardArray)) return false;
+          return true;
+        }
+
+        function isHistory(history) {
+          if (!Array.isArray(history)) return false;
+          for (const item of history) {
+            if (typeof item !== "string") return false;
+            let parsed = null;
+            try { parsed = JSON.parse(item); } catch (e) { return false; }
+            if (!isBoardState(parsed)) return false;
+          }
+          return true;
+        }
+
+        function readToggleState() {
+          const chk = document.getElementById("chk-autocheck");
+          return { autoCheck: !!(chk && chk.checked) };
+        }
+
+        function applyToggles(toggles) {
+          const chk = document.getElementById("chk-autocheck");
+          if (!chk || !toggles || typeof toggles !== "object") return;
+          if (typeof toggles.autoCheck === "boolean") chk.checked = toggles.autoCheck;
+        }
+
+        function buildSnapshot() {
+          return {
+            schemaVersion: SCHEMA_VERSION,
+            appVersion: Config.APP_VERSION,
+            variant: getVariant(),
+            savedAt: new Date().toISOString(),
+            state: {
+              current: State.current,
+              initial: State.initial,
+              history: State.history,
+              toggles: readToggleState()
+            }
+          };
+        }
+
+        function saveCurrentProgress() {
+          if (!storageAvailable()) return;
+          if (!State.current || !State.initial) return;
+          const key = getPrimaryKey();
+          const payload = buildSnapshot();
+          try {
+            localStorage.setItem(key, JSON.stringify(payload));
+          } catch (e) {}
+        }
+
+        function restoreFromLocal() {
+          if (!storageAvailable()) return false;
+          const key = getPrimaryKey();
+          migrateLegacyIfNeeded(key);
+
+          let raw = null;
+          try { raw = localStorage.getItem(key); } catch (e) { return false; }
+          if (!raw) return false;
+
+          let parsed = null;
+          try { parsed = JSON.parse(raw); } catch (e) { removeKey(key); return false; }
+          if (!parsed || parsed.schemaVersion !== SCHEMA_VERSION || !parsed.state) { removeKey(key); return false; }
+
+          const s = parsed.state;
+          if (!isBoardState(s.current) || !isBoardState(s.initial) || !isHistory(s.history)) {
+            removeKey(key);
+            return false;
+          }
+
+          State.current = s.current;
+          State.initial = s.initial;
+          State.history = s.history;
+          State.isAutoFinishing = false;
+          State.isAutoMoving = false;
+          State.isAnimating = false;
+          State.animatingCount = 0;
+          State.lastAnimationPromise = Promise.resolve();
+          State.lastRevealPromise = Promise.resolve();
+          State.lastAnimationEndAt = 0;
+          State.autoChainCount = 0;
+          applyToggles(s.toggles || {});
+          setLastMove("deal", { animate: false });
+          UI.render(State.current);
+          updateButtons();
+          clearStatus();
+          requestAutoCheck();
+          return true;
+        }
+
+        return {
+          saveCurrentProgress,
+          restoreFromLocal
+        };
+      })();
+
       /* --- [Simulator] --- */
       class Simulator {
         constructor() {}
@@ -414,6 +595,7 @@
         State.autoChainCount = 0;
         setLastMove("manual");
         UI.render(State.current); updateButtons(); requestAutoCheck();
+        Persistence.saveCurrentProgress();
       }
       
       function updateButtons() { 
@@ -503,6 +685,7 @@
         btnNew.disabled = false;
         setLastMove("deal", { animate: false });
         UI.render(State.current); updateButtons(); requestAutoCheck(); // Init Check
+        Persistence.saveCurrentProgress();
       }
 
       function buildTestState() {
@@ -545,6 +728,7 @@
             clearStatus();
             setLastMove("deal", { animate: false });
             UI.render(State.current); updateButtons(); requestAutoCheck();
+            Persistence.saveCurrentProgress();
         }
       }
 
@@ -767,6 +951,7 @@
             setLastMove("manual");
           }
           UI.render(State.current); 
+          Persistence.saveCurrentProgress();
           const endAt = State.lastAnimationEndAt;
           const afterReveal = () => { triggerAutoFoundation(); requestAutoCheck(); };
           if (revealCard) scheduleReveal(revealCard, "manual", afterReveal, endAt);
@@ -1088,7 +1273,9 @@
 
       window.addEventListener('load', () => {
         customElements.whenDefined('playing-card').then(() => {
-          setTimeout(Controller.startNewGame, 300);
+          if (!Persistence.restoreFromLocal()) {
+            setTimeout(Controller.startNewGame, 300);
+          }
         });
       });
     </script>

--- a/klondike-src.html
+++ b/klondike-src.html
@@ -186,6 +186,187 @@
 
       document.getElementById("app-version").textContent = `${Config.APP_VERSION}`;
 
+      /* --- [Persistence] --- */
+      const Persistence = (() => {
+        const SCHEMA_VERSION = 1;
+        const KEY_PREFIX = "klondike:save";
+
+        function getVariant() {
+          const name = (location.pathname.split("/").pop() || "").toLowerCase();
+          return name.includes("online") ? "online" : "offline";
+        }
+
+        function getPrimaryKey() {
+          return `${KEY_PREFIX}:${getVariant()}:v${SCHEMA_VERSION}`;
+        }
+
+        function getLegacyKeys() {
+          const variant = getVariant();
+          const common = ["klondike:save", "klondike-save"];
+          if (variant === "online") {
+            return [
+              ...common,
+              "klondike:save:index-online.html",
+              "klondike-save:index-online.html",
+              "klondike-save-online"
+            ];
+          }
+          return [
+            ...common,
+            "klondike:save:index.html",
+            "klondike:save:index-noanime.html",
+            "klondike-save:index.html",
+            "klondike-save:index-noanime.html",
+            "klondike-save-offline"
+          ];
+        }
+
+        function storageAvailable() {
+          try {
+            const key = "__klondike_storage_test__";
+            localStorage.setItem(key, "1");
+            localStorage.removeItem(key);
+            return true;
+          } catch (e) {
+            return false;
+          }
+        }
+
+        function removeKey(key) {
+          try { localStorage.removeItem(key); } catch (e) {}
+        }
+
+        function migrateLegacyIfNeeded(primaryKey) {
+          let exists = null;
+          try { exists = localStorage.getItem(primaryKey); } catch (e) { return; }
+          if (exists !== null) return;
+          const keys = getLegacyKeys();
+          for (const legacyKey of keys) {
+            let value = null;
+            try { value = localStorage.getItem(legacyKey); } catch (e) { return; }
+            if (value === null) continue;
+            try {
+              localStorage.setItem(primaryKey, value);
+              localStorage.removeItem(legacyKey);
+            } catch (e) {}
+            break;
+          }
+        }
+
+        function isCard(card) {
+          return !!card
+            && Number.isInteger(card.suit) && card.suit >= 0 && card.suit <= 3
+            && Number.isInteger(card.rank) && card.rank >= 1 && card.rank <= 13
+            && Number.isInteger(card.color) && (card.color === 0 || card.color === 1)
+            && typeof card.isOpen === "boolean";
+        }
+
+        function isCardArray(cards) {
+          return Array.isArray(cards) && cards.every(isCard);
+        }
+
+        function isBoardState(state) {
+          if (!state || typeof state !== "object") return false;
+          if (!isCardArray(state.stock) || !isCardArray(state.waste)) return false;
+          if (!Array.isArray(state.foundations) || state.foundations.length !== 4) return false;
+          if (!Array.isArray(state.tableau) || state.tableau.length !== 7) return false;
+          if (!state.foundations.every(isCardArray)) return false;
+          if (!state.tableau.every(isCardArray)) return false;
+          return true;
+        }
+
+        function isHistory(history) {
+          if (!Array.isArray(history)) return false;
+          for (const item of history) {
+            if (typeof item !== "string") return false;
+            let parsed = null;
+            try { parsed = JSON.parse(item); } catch (e) { return false; }
+            if (!isBoardState(parsed)) return false;
+          }
+          return true;
+        }
+
+        function readToggleState() {
+          const chk = document.getElementById("chk-autocheck");
+          return { autoCheck: !!(chk && chk.checked) };
+        }
+
+        function applyToggles(toggles) {
+          const chk = document.getElementById("chk-autocheck");
+          if (!chk || !toggles || typeof toggles !== "object") return;
+          if (typeof toggles.autoCheck === "boolean") chk.checked = toggles.autoCheck;
+        }
+
+        function buildSnapshot() {
+          return {
+            schemaVersion: SCHEMA_VERSION,
+            appVersion: Config.APP_VERSION,
+            variant: getVariant(),
+            savedAt: new Date().toISOString(),
+            state: {
+              current: State.current,
+              initial: State.initial,
+              history: State.history,
+              toggles: readToggleState()
+            }
+          };
+        }
+
+        function saveCurrentProgress() {
+          if (!storageAvailable()) return;
+          if (!State.current || !State.initial) return;
+          const key = getPrimaryKey();
+          const payload = buildSnapshot();
+          try {
+            localStorage.setItem(key, JSON.stringify(payload));
+          } catch (e) {}
+        }
+
+        function restoreFromLocal() {
+          if (!storageAvailable()) return false;
+          const key = getPrimaryKey();
+          migrateLegacyIfNeeded(key);
+
+          let raw = null;
+          try { raw = localStorage.getItem(key); } catch (e) { return false; }
+          if (!raw) return false;
+
+          let parsed = null;
+          try { parsed = JSON.parse(raw); } catch (e) { removeKey(key); return false; }
+          if (!parsed || parsed.schemaVersion !== SCHEMA_VERSION || !parsed.state) { removeKey(key); return false; }
+
+          const s = parsed.state;
+          if (!isBoardState(s.current) || !isBoardState(s.initial) || !isHistory(s.history)) {
+            removeKey(key);
+            return false;
+          }
+
+          State.current = s.current;
+          State.initial = s.initial;
+          State.history = s.history;
+          State.isAutoFinishing = false;
+          State.isAutoMoving = false;
+          State.isAnimating = false;
+          State.animatingCount = 0;
+          State.lastAnimationPromise = Promise.resolve();
+          State.lastRevealPromise = Promise.resolve();
+          State.lastAnimationEndAt = 0;
+          State.autoChainCount = 0;
+          applyToggles(s.toggles || {});
+          setLastMove("deal", { animate: false });
+          UI.render(State.current);
+          updateButtons();
+          clearStatus();
+          requestAutoCheck();
+          return true;
+        }
+
+        return {
+          saveCurrentProgress,
+          restoreFromLocal
+        };
+      })();
+
       /* --- [Simulator] --- */
       class Simulator {
         constructor() {}
@@ -414,6 +595,7 @@
         State.autoChainCount = 0;
         setLastMove("manual");
         UI.render(State.current); updateButtons(); requestAutoCheck();
+        Persistence.saveCurrentProgress();
       }
       
       function updateButtons() { 
@@ -503,6 +685,7 @@
         btnNew.disabled = false;
         setLastMove("deal", { animate: false });
         UI.render(State.current); updateButtons(); requestAutoCheck(); // Init Check
+        Persistence.saveCurrentProgress();
       }
 
       function buildTestState() {
@@ -545,6 +728,7 @@
             clearStatus();
             setLastMove("deal", { animate: false });
             UI.render(State.current); updateButtons(); requestAutoCheck();
+            Persistence.saveCurrentProgress();
         }
       }
 
@@ -767,6 +951,7 @@
             setLastMove("manual");
           }
           UI.render(State.current); 
+          Persistence.saveCurrentProgress();
           const endAt = State.lastAnimationEndAt;
           const afterReveal = () => { triggerAutoFoundation(); requestAutoCheck(); };
           if (revealCard) scheduleReveal(revealCard, "manual", afterReveal, endAt);
@@ -1088,7 +1273,9 @@
 
       window.addEventListener('load', () => {
         customElements.whenDefined('playing-card').then(() => {
-          setTimeout(Controller.startNewGame, 300);
+          if (!Persistence.restoreFromLocal()) {
+            setTimeout(Controller.startNewGame, 300);
+          }
         });
       });
     </script>

--- a/klondike.html
+++ b/klondike.html
@@ -198,6 +198,187 @@
 
       document.getElementById("app-version").textContent = `${Config.APP_VERSION}`;
 
+      /* --- [Persistence] --- */
+      const Persistence = (() => {
+        const SCHEMA_VERSION = 1;
+        const KEY_PREFIX = "klondike:save";
+
+        function getVariant() {
+          const name = (location.pathname.split("/").pop() || "").toLowerCase();
+          return name.includes("online") ? "online" : "offline";
+        }
+
+        function getPrimaryKey() {
+          return `${KEY_PREFIX}:${getVariant()}:v${SCHEMA_VERSION}`;
+        }
+
+        function getLegacyKeys() {
+          const variant = getVariant();
+          const common = ["klondike:save", "klondike-save"];
+          if (variant === "online") {
+            return [
+              ...common,
+              "klondike:save:index-online.html",
+              "klondike-save:index-online.html",
+              "klondike-save-online"
+            ];
+          }
+          return [
+            ...common,
+            "klondike:save:index.html",
+            "klondike:save:index-noanime.html",
+            "klondike-save:index.html",
+            "klondike-save:index-noanime.html",
+            "klondike-save-offline"
+          ];
+        }
+
+        function storageAvailable() {
+          try {
+            const key = "__klondike_storage_test__";
+            localStorage.setItem(key, "1");
+            localStorage.removeItem(key);
+            return true;
+          } catch (e) {
+            return false;
+          }
+        }
+
+        function removeKey(key) {
+          try { localStorage.removeItem(key); } catch (e) {}
+        }
+
+        function migrateLegacyIfNeeded(primaryKey) {
+          let exists = null;
+          try { exists = localStorage.getItem(primaryKey); } catch (e) { return; }
+          if (exists !== null) return;
+          const keys = getLegacyKeys();
+          for (const legacyKey of keys) {
+            let value = null;
+            try { value = localStorage.getItem(legacyKey); } catch (e) { return; }
+            if (value === null) continue;
+            try {
+              localStorage.setItem(primaryKey, value);
+              localStorage.removeItem(legacyKey);
+            } catch (e) {}
+            break;
+          }
+        }
+
+        function isCard(card) {
+          return !!card
+            && Number.isInteger(card.suit) && card.suit >= 0 && card.suit <= 3
+            && Number.isInteger(card.rank) && card.rank >= 1 && card.rank <= 13
+            && Number.isInteger(card.color) && (card.color === 0 || card.color === 1)
+            && typeof card.isOpen === "boolean";
+        }
+
+        function isCardArray(cards) {
+          return Array.isArray(cards) && cards.every(isCard);
+        }
+
+        function isBoardState(state) {
+          if (!state || typeof state !== "object") return false;
+          if (!isCardArray(state.stock) || !isCardArray(state.waste)) return false;
+          if (!Array.isArray(state.foundations) || state.foundations.length !== 4) return false;
+          if (!Array.isArray(state.tableau) || state.tableau.length !== 7) return false;
+          if (!state.foundations.every(isCardArray)) return false;
+          if (!state.tableau.every(isCardArray)) return false;
+          return true;
+        }
+
+        function isHistory(history) {
+          if (!Array.isArray(history)) return false;
+          for (const item of history) {
+            if (typeof item !== "string") return false;
+            let parsed = null;
+            try { parsed = JSON.parse(item); } catch (e) { return false; }
+            if (!isBoardState(parsed)) return false;
+          }
+          return true;
+        }
+
+        function readToggleState() {
+          const chk = document.getElementById("chk-autocheck");
+          return { autoCheck: !!(chk && chk.checked) };
+        }
+
+        function applyToggles(toggles) {
+          const chk = document.getElementById("chk-autocheck");
+          if (!chk || !toggles || typeof toggles !== "object") return;
+          if (typeof toggles.autoCheck === "boolean") chk.checked = toggles.autoCheck;
+        }
+
+        function buildSnapshot() {
+          return {
+            schemaVersion: SCHEMA_VERSION,
+            appVersion: Config.APP_VERSION,
+            variant: getVariant(),
+            savedAt: new Date().toISOString(),
+            state: {
+              current: State.current,
+              initial: State.initial,
+              history: State.history,
+              toggles: readToggleState()
+            }
+          };
+        }
+
+        function saveCurrentProgress() {
+          if (!storageAvailable()) return;
+          if (!State.current || !State.initial) return;
+          const key = getPrimaryKey();
+          const payload = buildSnapshot();
+          try {
+            localStorage.setItem(key, JSON.stringify(payload));
+          } catch (e) {}
+        }
+
+        function restoreFromLocal() {
+          if (!storageAvailable()) return false;
+          const key = getPrimaryKey();
+          migrateLegacyIfNeeded(key);
+
+          let raw = null;
+          try { raw = localStorage.getItem(key); } catch (e) { return false; }
+          if (!raw) return false;
+
+          let parsed = null;
+          try { parsed = JSON.parse(raw); } catch (e) { removeKey(key); return false; }
+          if (!parsed || parsed.schemaVersion !== SCHEMA_VERSION || !parsed.state) { removeKey(key); return false; }
+
+          const s = parsed.state;
+          if (!isBoardState(s.current) || !isBoardState(s.initial) || !isHistory(s.history)) {
+            removeKey(key);
+            return false;
+          }
+
+          State.current = s.current;
+          State.initial = s.initial;
+          State.history = s.history;
+          State.isAutoFinishing = false;
+          State.isAutoMoving = false;
+          State.isAnimating = false;
+          State.animatingCount = 0;
+          State.lastAnimationPromise = Promise.resolve();
+          State.lastRevealPromise = Promise.resolve();
+          State.lastAnimationEndAt = 0;
+          State.autoChainCount = 0;
+          applyToggles(s.toggles || {});
+          setLastMove("deal", { animate: false });
+          UI.render(State.current);
+          updateButtons();
+          clearStatus();
+          requestAutoCheck();
+          return true;
+        }
+
+        return {
+          saveCurrentProgress,
+          restoreFromLocal
+        };
+      })();
+
       /* --- [Simulator] --- */
       class Simulator {
         constructor() {}
@@ -426,6 +607,7 @@
         State.autoChainCount = 0;
         setLastMove("manual");
         UI.render(State.current); updateButtons(); requestAutoCheck();
+        Persistence.saveCurrentProgress();
       }
       
       function updateButtons() { 
@@ -515,6 +697,7 @@
         btnNew.disabled = false;
         setLastMove("deal", { animate: false });
         UI.render(State.current); updateButtons(); requestAutoCheck(); // Init Check
+        Persistence.saveCurrentProgress();
       }
 
       function buildTestState() {
@@ -557,6 +740,7 @@
             clearStatus();
             setLastMove("deal", { animate: false });
             UI.render(State.current); updateButtons(); requestAutoCheck();
+            Persistence.saveCurrentProgress();
         }
       }
 
@@ -779,6 +963,7 @@
             setLastMove("manual");
           }
           UI.render(State.current); 
+          Persistence.saveCurrentProgress();
           const endAt = State.lastAnimationEndAt;
           const afterReveal = () => { triggerAutoFoundation(); requestAutoCheck(); };
           if (revealCard) scheduleReveal(revealCard, "manual", afterReveal, endAt);
@@ -1100,7 +1285,9 @@
 
       window.addEventListener('load', () => {
         customElements.whenDefined('playing-card').then(() => {
-          setTimeout(Controller.startNewGame, 300);
+          if (!Persistence.restoreFromLocal()) {
+            setTimeout(Controller.startNewGame, 300);
+          }
         });
       });
     </script>


### PR DESCRIPTION
### 概要
プレイ中データの `localStorage` 保存/復元を実装しました。
あわせて、ビルド関連TODOの完了マーク付けと、ストレージ機能の手動確認チェックリストをドキュメントへ追加しています。

### 変更内容

#### 1) ストレージ保存/復元の実装（`klondike-src.html`）
- `Persistence` モジュールを追加
- スキーマ付き保存データを導入
  - `schemaVersion`
  - `appVersion`
  - `variant`（offline / online）
  - `state.current`
  - `state.initial`
  - `state.history`（Undo履歴）
  - `state.toggles.autoCheck`
- 破損データ/不正データの安全リセットを実装（読み込み失敗時に削除）
- 旧キーからの1回移行を実装（`index*.html` 系 legacy key）

#### 2) 保存トリガー（合意仕様反映）
以下の完了時に保存するよう実装:
- `handleSlotClick()` 成功時
- `startNewGame()` 完了時
- `restartGame()` 完了時
- `popHistory()`（Undo）完了時

#### 3) 起動時自動復元
- 起動時に `restoreFromLocal()` を実行
- 復元成功時はその盤面を表示
- 復元失敗時のみ `startNewGame()` を実行

#### 4) 生成物更新
- `klondike.html`
- `klondike-online.html` （`klondike-src.html` から再生成）

#### 5) ドキュメント更新
- `README.md`
  - ストレージの手動チェックリスト（英日）を追加
- `ARCHITECTURE.md`
  - 実施済みのビルド関連TODOに `[DONE]` を付与

### 確認観点
- 手動操作後リロードで復元されること
- `New Game` / `Restart` / `Undo` 後に保存されること
- 破損JSONで安全に新規開始へフォールバックすること
- offline/online でキーが分離されること
- legacy key がある場合に1回移行されること