### PR TITLE
feat: Moves表示とハンバーガーメニューを追加し、ビルド時にテスト実行を必須化

### DIFF
--- a/klondike-online.html
+++ b/klondike-online.html
@@ -34,6 +34,25 @@
       .github-link:hover { opacity: 1; }
       .github-link svg { width: 16px; height: 16px; display: block; }
       .controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; justify-content: center; }
+      .menu { position: relative; display: inline-flex; align-items: center; }
+      .menu-btn { min-width: 40px; padding: 6px 10px; font-size: 16px; line-height: 1; }
+      .menu-panel {
+        position: absolute;
+        top: calc(100% + 8px);
+        right: 0;
+        min-width: 220px;
+        display: grid;
+        gap: 8px;
+        padding: 10px;
+        background: rgba(0, 0, 0, 0.88);
+        border: 1px solid rgba(255, 255, 255, 0.35);
+        border-radius: 8px;
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+        z-index: 120;
+      }
+      .menu-panel[hidden] { display: none; }
+      .menu-panel button { width: 100%; text-align: left; }
+      .menu-toggle { width: 100%; justify-content: flex-start; }
       
       .toggle-label { display: flex; align-items: center; cursor: pointer; color: white; font-size: 12px; gap: 5px; background: rgba(0,0,0,0.2); padding: 4px 8px; border-radius: 4px; }
       .toggle-label input { cursor: pointer; }
@@ -61,6 +80,7 @@
         }
         header { padding: 12px 10px; }
         .controls { width: 100%; }
+        .menu { margin-left: auto; }
         .board { padding: 10px var(--board-pad); gap: 20px; }
       }
 
@@ -109,14 +129,20 @@
       </h1>
       <div class="controls">
         <span id="status-msg"></span>
-        <label class="toggle-label" title="Auto check + debug logs">
-            <input type="checkbox" id="chk-autocheck" checked> Solvability Check
-        </label>
-        <button id="btn-undo" disabled>Undo</button>
-        <button id="btn-restart" disabled>Restart</button>
+        <span id="moves-msg">Moves: 0</span>
         <button id="btn-hint">Hint</button>
-        <button id="new-game">New Game</button>
-        <button id="btn-test">Test</button>
+        <button id="btn-undo" disabled>Undo</button>
+        <div class="menu">
+          <button id="btn-menu" class="menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="menu-panel">☰</button>
+          <div id="menu-panel" class="menu-panel" hidden>
+            <button id="btn-restart" disabled>Restart</button>
+            <button id="new-game">New Game</button>
+            <label class="toggle-label menu-toggle" title="Auto check + debug logs">
+                <input type="checkbox" id="chk-autocheck" checked> Solvability Check
+            </label>
+            <button id="btn-test">Test</button>
+          </div>
+        </div>
       </div>
     </header>
     <main class="board">
@@ -146,7 +172,7 @@
         <script>
       /* --- [Config] --- */
       const Config = {
-        APP_VERSION: "v20260304",
+        APP_VERSION: "v20260305",
         // 【変更点1】 並び順を スペード(0), ハート(1), クラブ(2), ダイヤ(3) に変更
         SUITS: ["spades", "hearts", "clubs", "diamonds"],
         RANKS: ["ace", "2", "3", "4", "5", "6", "7", "8", "9", "ten", "jack", "queen", "king"],
@@ -173,6 +199,8 @@
         current: null,
         initial: null,
         history: [],
+        moveCountHistory: [],
+        manualMoveCount: 0,
         isAutoFinishing: false,
         isAutoMoving: false,
         isAnimating: false,
@@ -185,6 +213,15 @@
       };
 
       document.getElementById("app-version").textContent = `${Config.APP_VERSION}`;
+      function updateMoveCounter() {
+        const el = document.getElementById("moves-msg");
+        if (el) el.textContent = `Moves: ${State.manualMoveCount}`;
+      }
+      function incrementMoveCount() {
+        State.manualMoveCount += 1;
+        updateMoveCounter();
+      }
+      updateMoveCounter();
 
       /* --- [Persistence] --- */
       const Persistence = (() => {
@@ -285,6 +322,9 @@
           }
           return true;
         }
+        function isMoveCountHistory(history) {
+          return Array.isArray(history) && history.every(x => Number.isInteger(x) && x >= 0);
+        }
 
         function readToggleState() {
           const chk = document.getElementById("chk-autocheck");
@@ -307,6 +347,8 @@
               current: State.current,
               initial: State.initial,
               history: State.history,
+              manualMoveCount: State.manualMoveCount,
+              moveCountHistory: State.moveCountHistory,
               toggles: readToggleState()
             }
           };
@@ -344,6 +386,10 @@
           State.current = s.current;
           State.initial = s.initial;
           State.history = s.history;
+          if (Number.isInteger(s.manualMoveCount) && s.manualMoveCount >= 0) State.manualMoveCount = s.manualMoveCount;
+          else State.manualMoveCount = 0;
+          if (isMoveCountHistory(s.moveCountHistory)) State.moveCountHistory = s.moveCountHistory;
+          else State.moveCountHistory = Array(State.history.length).fill(0);
           State.isAutoFinishing = false;
           State.isAutoMoving = false;
           State.isAnimating = false;
@@ -355,6 +401,7 @@
           applyToggles(s.toggles || {});
           setLastMove("deal", { animate: false });
           UI.render(State.current);
+          updateMoveCounter();
           updateButtons();
           clearStatus();
           requestAutoCheck();
@@ -374,7 +421,9 @@
       function pushHistory() {
         if (State.current) {
             if (State.history.length > 1000) State.history.shift(); 
+            if (State.moveCountHistory.length > 1000) State.moveCountHistory.shift();
             State.history.push(JSON.stringify(State.current));
+            State.moveCountHistory.push(State.manualMoveCount);
             updateButtons();
         }
       }
@@ -383,8 +432,11 @@
         if (State.isAutoMoving || State.isAnimating) return;
         if (State.history.length === 0) return;
         State.current = JSON.parse(State.history.pop());
+        const prevCount = State.moveCountHistory.pop();
+        State.manualMoveCount = Number.isInteger(prevCount) ? prevCount : 0;
         State.autoChainCount = 0;
         setLastMove("manual");
+        updateMoveCounter();
         UI.render(State.current); updateButtons(); requestAutoCheck();
         Persistence.saveCurrentProgress();
       }
@@ -469,12 +521,15 @@
         State.current = newState;
         State.initial = JSON.parse(JSON.stringify(newState));
         State.history = []; 
+        State.moveCountHistory = [];
+        State.manualMoveCount = 0;
         State.isAutoFinishing = false;
         State.isAutoMoving = false;
         State.autoChainCount = 0;
         clearStatus();
         btnNew.disabled = false;
         setLastMove("deal", { animate: false });
+        updateMoveCounter();
         UI.render(State.current); updateButtons(); requestAutoCheck(); // Init Check
         Persistence.saveCurrentProgress();
       }
@@ -498,11 +553,14 @@
         State.current = testState;
         State.initial = JSON.parse(JSON.stringify(testState));
         State.history = [];
+        State.moveCountHistory = [];
+        State.manualMoveCount = 0;
         State.isAutoFinishing = false;
         State.isAutoMoving = false;
         State.autoChainCount = 0;
         clearStatus();
         setLastMove("deal", { animate: false });
+        updateMoveCounter();
         UI.render(State.current); updateButtons(); requestAutoCheck();
         checkVictoryCondition();
       }
@@ -513,11 +571,14 @@
         if(confirm("Restart from the beginning?")) {
             State.current = JSON.parse(JSON.stringify(State.initial));
             State.history = [];
+            State.moveCountHistory = [];
+            State.manualMoveCount = 0;
             State.isAutoFinishing = false;
             State.isAutoMoving = false;
             State.autoChainCount = 0;
             clearStatus();
             setLastMove("deal", { animate: false });
+            updateMoveCounter();
             UI.render(State.current); updateButtons(); requestAutoCheck();
             Persistence.saveCurrentProgress();
         }
@@ -593,6 +654,7 @@
           State.autoChainCount = 0;
           setLastMove("draw", { cardKey: getCardKey(c), prevWasteCard: prevWasteTop });
         }
+        incrementMoveCount();
         UI.render(State.current); triggerAutoFoundation();
       }
 
@@ -640,6 +702,7 @@
           state.waste = [];
           setLastMove("manual", { animate: false });
         }
+        incrementMoveCount();
         State.autoChainCount = 0;
         UI.render(State.current);
         const endAt = State.lastAnimationEndAt;
@@ -737,6 +800,7 @@
 
         if (moveSuccess) { 
           State.autoChainCount = 0;
+          incrementMoveCount();
           if (movedToFoundation) {
             setLastMove("manual", { foundationIdx, prevFoundationCard });
           } else {
@@ -1065,6 +1129,40 @@
         Controller.startNewGame();
       };
       document.getElementById("chk-autocheck").onchange = () => { Controller.requestAutoCheck(); };
+      (function setupMenu() {
+        const menuBtn = document.getElementById("btn-menu");
+        const menuPanel = document.getElementById("menu-panel");
+        if (!menuBtn || !menuPanel) return;
+        const closeMenu = () => {
+          menuPanel.hidden = true;
+          menuBtn.setAttribute("aria-expanded", "false");
+        };
+        const openMenu = () => {
+          menuPanel.hidden = false;
+          menuBtn.setAttribute("aria-expanded", "true");
+        };
+        menuBtn.onclick = (e) => {
+          e.stopPropagation();
+          if (menuPanel.hidden) openMenu();
+          else closeMenu();
+        };
+        menuPanel.addEventListener("click", (e) => {
+          e.stopPropagation();
+        });
+        document.addEventListener("click", () => {
+          closeMenu();
+        });
+        document.addEventListener("keydown", (e) => {
+          if (e.key === "Escape") closeMenu();
+        });
+        ["btn-restart", "new-game", "btn-test", "chk-autocheck"].forEach((id) => {
+          const el = document.getElementById(id);
+          if (!el) return;
+          el.addEventListener("click", () => {
+            closeMenu();
+          });
+        });
+      })();
 
       window.addEventListener('load', () => {
         customElements.whenDefined('playing-card').then(() => {

--- a/klondike-src.html
+++ b/klondike-src.html
@@ -34,6 +34,25 @@
       .github-link:hover { opacity: 1; }
       .github-link svg { width: 16px; height: 16px; display: block; }
       .controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; justify-content: center; }
+      .menu { position: relative; display: inline-flex; align-items: center; }
+      .menu-btn { min-width: 40px; padding: 6px 10px; font-size: 16px; line-height: 1; }
+      .menu-panel {
+        position: absolute;
+        top: calc(100% + 8px);
+        right: 0;
+        min-width: 220px;
+        display: grid;
+        gap: 8px;
+        padding: 10px;
+        background: rgba(0, 0, 0, 0.88);
+        border: 1px solid rgba(255, 255, 255, 0.35);
+        border-radius: 8px;
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+        z-index: 120;
+      }
+      .menu-panel[hidden] { display: none; }
+      .menu-panel button { width: 100%; text-align: left; }
+      .menu-toggle { width: 100%; justify-content: flex-start; }
       
       .toggle-label { display: flex; align-items: center; cursor: pointer; color: white; font-size: 12px; gap: 5px; background: rgba(0,0,0,0.2); padding: 4px 8px; border-radius: 4px; }
       .toggle-label input { cursor: pointer; }
@@ -61,6 +80,7 @@
         }
         header { padding: 12px 10px; }
         .controls { width: 100%; }
+        .menu { margin-left: auto; }
         .board { padding: 10px var(--board-pad); gap: 20px; }
       }
 
@@ -109,14 +129,20 @@
       </h1>
       <div class="controls">
         <span id="status-msg"></span>
-        <label class="toggle-label" title="Auto check + debug logs">
-            <input type="checkbox" id="chk-autocheck" checked> Solvability Check
-        </label>
-        <button id="btn-undo" disabled>Undo</button>
-        <button id="btn-restart" disabled>Restart</button>
+        <span id="moves-msg">Moves: 0</span>
         <button id="btn-hint">Hint</button>
-        <button id="new-game">New Game</button>
-        <button id="btn-test">Test</button>
+        <button id="btn-undo" disabled>Undo</button>
+        <div class="menu">
+          <button id="btn-menu" class="menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="menu-panel">☰</button>
+          <div id="menu-panel" class="menu-panel" hidden>
+            <button id="btn-restart" disabled>Restart</button>
+            <button id="new-game">New Game</button>
+            <label class="toggle-label menu-toggle" title="Auto check + debug logs">
+                <input type="checkbox" id="chk-autocheck" checked> Solvability Check
+            </label>
+            <button id="btn-test">Test</button>
+          </div>
+        </div>
       </div>
     </header>
     <main class="board">

--- a/klondike.html
+++ b/klondike.html
@@ -46,6 +46,25 @@
       .github-link:hover { opacity: 1; }
       .github-link svg { width: 16px; height: 16px; display: block; }
       .controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; justify-content: center; }
+      .menu { position: relative; display: inline-flex; align-items: center; }
+      .menu-btn { min-width: 40px; padding: 6px 10px; font-size: 16px; line-height: 1; }
+      .menu-panel {
+        position: absolute;
+        top: calc(100% + 8px);
+        right: 0;
+        min-width: 220px;
+        display: grid;
+        gap: 8px;
+        padding: 10px;
+        background: rgba(0, 0, 0, 0.88);
+        border: 1px solid rgba(255, 255, 255, 0.35);
+        border-radius: 8px;
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+        z-index: 120;
+      }
+      .menu-panel[hidden] { display: none; }
+      .menu-panel button { width: 100%; text-align: left; }
+      .menu-toggle { width: 100%; justify-content: flex-start; }
       
       .toggle-label { display: flex; align-items: center; cursor: pointer; color: white; font-size: 12px; gap: 5px; background: rgba(0,0,0,0.2); padding: 4px 8px; border-radius: 4px; }
       .toggle-label input { cursor: pointer; }
@@ -73,6 +92,7 @@
         }
         header { padding: 12px 10px; }
         .controls { width: 100%; }
+        .menu { margin-left: auto; }
         .board { padding: 10px var(--board-pad); gap: 20px; }
       }
 
@@ -121,14 +141,20 @@
       </h1>
       <div class="controls">
         <span id="status-msg"></span>
-        <label class="toggle-label" title="Auto check + debug logs">
-            <input type="checkbox" id="chk-autocheck" checked> Solvability Check
-        </label>
-        <button id="btn-undo" disabled>Undo</button>
-        <button id="btn-restart" disabled>Restart</button>
+        <span id="moves-msg">Moves: 0</span>
         <button id="btn-hint">Hint</button>
-        <button id="new-game">New Game</button>
-        <button id="btn-test">Test</button>
+        <button id="btn-undo" disabled>Undo</button>
+        <div class="menu">
+          <button id="btn-menu" class="menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="menu-panel">☰</button>
+          <div id="menu-panel" class="menu-panel" hidden>
+            <button id="btn-restart" disabled>Restart</button>
+            <button id="new-game">New Game</button>
+            <label class="toggle-label menu-toggle" title="Auto check + debug logs">
+                <input type="checkbox" id="chk-autocheck" checked> Solvability Check
+            </label>
+            <button id="btn-test">Test</button>
+          </div>
+        </div>
       </div>
     </header>
     <main class="board">
@@ -158,7 +184,7 @@
         <script>
       /* --- [Config] --- */
       const Config = {
-        APP_VERSION: "v20260304",
+        APP_VERSION: "v20260305",
         // 【変更点1】 並び順を スペード(0), ハート(1), クラブ(2), ダイヤ(3) に変更
         SUITS: ["spades", "hearts", "clubs", "diamonds"],
         RANKS: ["ace", "2", "3", "4", "5", "6", "7", "8", "9", "ten", "jack", "queen", "king"],
@@ -185,6 +211,8 @@
         current: null,
         initial: null,
         history: [],
+        moveCountHistory: [],
+        manualMoveCount: 0,
         isAutoFinishing: false,
         isAutoMoving: false,
         isAnimating: false,
@@ -197,6 +225,15 @@
       };
 
       document.getElementById("app-version").textContent = `${Config.APP_VERSION}`;
+      function updateMoveCounter() {
+        const el = document.getElementById("moves-msg");
+        if (el) el.textContent = `Moves: ${State.manualMoveCount}`;
+      }
+      function incrementMoveCount() {
+        State.manualMoveCount += 1;
+        updateMoveCounter();
+      }
+      updateMoveCounter();
 
       /* --- [Persistence] --- */
       const Persistence = (() => {
@@ -297,6 +334,9 @@
           }
           return true;
         }
+        function isMoveCountHistory(history) {
+          return Array.isArray(history) && history.every(x => Number.isInteger(x) && x >= 0);
+        }
 
         function readToggleState() {
           const chk = document.getElementById("chk-autocheck");
@@ -319,6 +359,8 @@
               current: State.current,
               initial: State.initial,
               history: State.history,
+              manualMoveCount: State.manualMoveCount,
+              moveCountHistory: State.moveCountHistory,
               toggles: readToggleState()
             }
           };
@@ -356,6 +398,10 @@
           State.current = s.current;
           State.initial = s.initial;
           State.history = s.history;
+          if (Number.isInteger(s.manualMoveCount) && s.manualMoveCount >= 0) State.manualMoveCount = s.manualMoveCount;
+          else State.manualMoveCount = 0;
+          if (isMoveCountHistory(s.moveCountHistory)) State.moveCountHistory = s.moveCountHistory;
+          else State.moveCountHistory = Array(State.history.length).fill(0);
           State.isAutoFinishing = false;
           State.isAutoMoving = false;
           State.isAnimating = false;
@@ -367,6 +413,7 @@
           applyToggles(s.toggles || {});
           setLastMove("deal", { animate: false });
           UI.render(State.current);
+          updateMoveCounter();
           updateButtons();
           clearStatus();
           requestAutoCheck();
@@ -386,7 +433,9 @@
       function pushHistory() {
         if (State.current) {
             if (State.history.length > 1000) State.history.shift(); 
+            if (State.moveCountHistory.length > 1000) State.moveCountHistory.shift();
             State.history.push(JSON.stringify(State.current));
+            State.moveCountHistory.push(State.manualMoveCount);
             updateButtons();
         }
       }
@@ -395,8 +444,11 @@
         if (State.isAutoMoving || State.isAnimating) return;
         if (State.history.length === 0) return;
         State.current = JSON.parse(State.history.pop());
+        const prevCount = State.moveCountHistory.pop();
+        State.manualMoveCount = Number.isInteger(prevCount) ? prevCount : 0;
         State.autoChainCount = 0;
         setLastMove("manual");
+        updateMoveCounter();
         UI.render(State.current); updateButtons(); requestAutoCheck();
         Persistence.saveCurrentProgress();
       }
@@ -481,12 +533,15 @@
         State.current = newState;
         State.initial = JSON.parse(JSON.stringify(newState));
         State.history = []; 
+        State.moveCountHistory = [];
+        State.manualMoveCount = 0;
         State.isAutoFinishing = false;
         State.isAutoMoving = false;
         State.autoChainCount = 0;
         clearStatus();
         btnNew.disabled = false;
         setLastMove("deal", { animate: false });
+        updateMoveCounter();
         UI.render(State.current); updateButtons(); requestAutoCheck(); // Init Check
         Persistence.saveCurrentProgress();
       }
@@ -510,11 +565,14 @@
         State.current = testState;
         State.initial = JSON.parse(JSON.stringify(testState));
         State.history = [];
+        State.moveCountHistory = [];
+        State.manualMoveCount = 0;
         State.isAutoFinishing = false;
         State.isAutoMoving = false;
         State.autoChainCount = 0;
         clearStatus();
         setLastMove("deal", { animate: false });
+        updateMoveCounter();
         UI.render(State.current); updateButtons(); requestAutoCheck();
         checkVictoryCondition();
       }
@@ -525,11 +583,14 @@
         if(confirm("Restart from the beginning?")) {
             State.current = JSON.parse(JSON.stringify(State.initial));
             State.history = [];
+            State.moveCountHistory = [];
+            State.manualMoveCount = 0;
             State.isAutoFinishing = false;
             State.isAutoMoving = false;
             State.autoChainCount = 0;
             clearStatus();
             setLastMove("deal", { animate: false });
+            updateMoveCounter();
             UI.render(State.current); updateButtons(); requestAutoCheck();
             Persistence.saveCurrentProgress();
         }
@@ -605,6 +666,7 @@
           State.autoChainCount = 0;
           setLastMove("draw", { cardKey: getCardKey(c), prevWasteCard: prevWasteTop });
         }
+        incrementMoveCount();
         UI.render(State.current); triggerAutoFoundation();
       }
 
@@ -652,6 +714,7 @@
           state.waste = [];
           setLastMove("manual", { animate: false });
         }
+        incrementMoveCount();
         State.autoChainCount = 0;
         UI.render(State.current);
         const endAt = State.lastAnimationEndAt;
@@ -749,6 +812,7 @@
 
         if (moveSuccess) { 
           State.autoChainCount = 0;
+          incrementMoveCount();
           if (movedToFoundation) {
             setLastMove("manual", { foundationIdx, prevFoundationCard });
           } else {
@@ -1077,6 +1141,40 @@
         Controller.startNewGame();
       };
       document.getElementById("chk-autocheck").onchange = () => { Controller.requestAutoCheck(); };
+      (function setupMenu() {
+        const menuBtn = document.getElementById("btn-menu");
+        const menuPanel = document.getElementById("menu-panel");
+        if (!menuBtn || !menuPanel) return;
+        const closeMenu = () => {
+          menuPanel.hidden = true;
+          menuBtn.setAttribute("aria-expanded", "false");
+        };
+        const openMenu = () => {
+          menuPanel.hidden = false;
+          menuBtn.setAttribute("aria-expanded", "true");
+        };
+        menuBtn.onclick = (e) => {
+          e.stopPropagation();
+          if (menuPanel.hidden) openMenu();
+          else closeMenu();
+        };
+        menuPanel.addEventListener("click", (e) => {
+          e.stopPropagation();
+        });
+        document.addEventListener("click", () => {
+          closeMenu();
+        });
+        document.addEventListener("keydown", (e) => {
+          if (e.key === "Escape") closeMenu();
+        });
+        ["btn-restart", "new-game", "btn-test", "chk-autocheck"].forEach((id) => {
+          const el = document.getElementById(id);
+          if (!el) return;
+          el.addEventListener("click", () => {
+            closeMenu();
+          });
+        });
+      })();
 
       window.addEventListener('load', () => {
         customElements.whenDefined('playing-card').then(() => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "description": "Klondike static web app build scripts",
   "scripts": {
-    "build": "node scripts/build.mjs",
+    "build": "npm run test:unit && npm run build:html",
+    "build:html": "node scripts/build.mjs",
+    "check:all": "npm run test:unit && npm run build:html",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
       /* --- [Config] --- */
       const Config = {
-        APP_VERSION: "v20260304",
+        APP_VERSION: "v20260305",
         // 【変更点1】 並び順を スペード(0), ハート(1), クラブ(2), ダイヤ(3) に変更
         SUITS: ["spades", "hearts", "clubs", "diamonds"],
         RANKS: ["ace", "2", "3", "4", "5", "6", "7", "8", "9", "ten", "jack", "queen", "king"],
@@ -27,6 +27,8 @@
         current: null,
         initial: null,
         history: [],
+        moveCountHistory: [],
+        manualMoveCount: 0,
         isAutoFinishing: false,
         isAutoMoving: false,
         isAnimating: false,
@@ -39,6 +41,15 @@
       };
 
       document.getElementById("app-version").textContent = `${Config.APP_VERSION}`;
+      function updateMoveCounter() {
+        const el = document.getElementById("moves-msg");
+        if (el) el.textContent = `Moves: ${State.manualMoveCount}`;
+      }
+      function incrementMoveCount() {
+        State.manualMoveCount += 1;
+        updateMoveCounter();
+      }
+      updateMoveCounter();
 
       /* --- [Persistence] --- */
       const Persistence = (() => {
@@ -139,6 +150,9 @@
           }
           return true;
         }
+        function isMoveCountHistory(history) {
+          return Array.isArray(history) && history.every(x => Number.isInteger(x) && x >= 0);
+        }
 
         function readToggleState() {
           const chk = document.getElementById("chk-autocheck");
@@ -161,6 +175,8 @@
               current: State.current,
               initial: State.initial,
               history: State.history,
+              manualMoveCount: State.manualMoveCount,
+              moveCountHistory: State.moveCountHistory,
               toggles: readToggleState()
             }
           };
@@ -198,6 +214,10 @@
           State.current = s.current;
           State.initial = s.initial;
           State.history = s.history;
+          if (Number.isInteger(s.manualMoveCount) && s.manualMoveCount >= 0) State.manualMoveCount = s.manualMoveCount;
+          else State.manualMoveCount = 0;
+          if (isMoveCountHistory(s.moveCountHistory)) State.moveCountHistory = s.moveCountHistory;
+          else State.moveCountHistory = Array(State.history.length).fill(0);
           State.isAutoFinishing = false;
           State.isAutoMoving = false;
           State.isAnimating = false;
@@ -209,6 +229,7 @@
           applyToggles(s.toggles || {});
           setLastMove("deal", { animate: false });
           UI.render(State.current);
+          updateMoveCounter();
           updateButtons();
           clearStatus();
           requestAutoCheck();
@@ -228,7 +249,9 @@
       function pushHistory() {
         if (State.current) {
             if (State.history.length > 1000) State.history.shift(); 
+            if (State.moveCountHistory.length > 1000) State.moveCountHistory.shift();
             State.history.push(JSON.stringify(State.current));
+            State.moveCountHistory.push(State.manualMoveCount);
             updateButtons();
         }
       }
@@ -237,8 +260,11 @@
         if (State.isAutoMoving || State.isAnimating) return;
         if (State.history.length === 0) return;
         State.current = JSON.parse(State.history.pop());
+        const prevCount = State.moveCountHistory.pop();
+        State.manualMoveCount = Number.isInteger(prevCount) ? prevCount : 0;
         State.autoChainCount = 0;
         setLastMove("manual");
+        updateMoveCounter();
         UI.render(State.current); updateButtons(); requestAutoCheck();
         Persistence.saveCurrentProgress();
       }
@@ -323,12 +349,15 @@
         State.current = newState;
         State.initial = JSON.parse(JSON.stringify(newState));
         State.history = []; 
+        State.moveCountHistory = [];
+        State.manualMoveCount = 0;
         State.isAutoFinishing = false;
         State.isAutoMoving = false;
         State.autoChainCount = 0;
         clearStatus();
         btnNew.disabled = false;
         setLastMove("deal", { animate: false });
+        updateMoveCounter();
         UI.render(State.current); updateButtons(); requestAutoCheck(); // Init Check
         Persistence.saveCurrentProgress();
       }
@@ -352,11 +381,14 @@
         State.current = testState;
         State.initial = JSON.parse(JSON.stringify(testState));
         State.history = [];
+        State.moveCountHistory = [];
+        State.manualMoveCount = 0;
         State.isAutoFinishing = false;
         State.isAutoMoving = false;
         State.autoChainCount = 0;
         clearStatus();
         setLastMove("deal", { animate: false });
+        updateMoveCounter();
         UI.render(State.current); updateButtons(); requestAutoCheck();
         checkVictoryCondition();
       }
@@ -367,11 +399,14 @@
         if(confirm("Restart from the beginning?")) {
             State.current = JSON.parse(JSON.stringify(State.initial));
             State.history = [];
+            State.moveCountHistory = [];
+            State.manualMoveCount = 0;
             State.isAutoFinishing = false;
             State.isAutoMoving = false;
             State.autoChainCount = 0;
             clearStatus();
             setLastMove("deal", { animate: false });
+            updateMoveCounter();
             UI.render(State.current); updateButtons(); requestAutoCheck();
             Persistence.saveCurrentProgress();
         }
@@ -447,6 +482,7 @@
           State.autoChainCount = 0;
           setLastMove("draw", { cardKey: getCardKey(c), prevWasteCard: prevWasteTop });
         }
+        incrementMoveCount();
         UI.render(State.current); triggerAutoFoundation();
       }
 
@@ -494,6 +530,7 @@
           state.waste = [];
           setLastMove("manual", { animate: false });
         }
+        incrementMoveCount();
         State.autoChainCount = 0;
         UI.render(State.current);
         const endAt = State.lastAnimationEndAt;
@@ -591,6 +628,7 @@
 
         if (moveSuccess) { 
           State.autoChainCount = 0;
+          incrementMoveCount();
           if (movedToFoundation) {
             setLastMove("manual", { foundationIdx, prevFoundationCard });
           } else {
@@ -919,6 +957,40 @@
         Controller.startNewGame();
       };
       document.getElementById("chk-autocheck").onchange = () => { Controller.requestAutoCheck(); };
+      (function setupMenu() {
+        const menuBtn = document.getElementById("btn-menu");
+        const menuPanel = document.getElementById("menu-panel");
+        if (!menuBtn || !menuPanel) return;
+        const closeMenu = () => {
+          menuPanel.hidden = true;
+          menuBtn.setAttribute("aria-expanded", "false");
+        };
+        const openMenu = () => {
+          menuPanel.hidden = false;
+          menuBtn.setAttribute("aria-expanded", "true");
+        };
+        menuBtn.onclick = (e) => {
+          e.stopPropagation();
+          if (menuPanel.hidden) openMenu();
+          else closeMenu();
+        };
+        menuPanel.addEventListener("click", (e) => {
+          e.stopPropagation();
+        });
+        document.addEventListener("click", () => {
+          closeMenu();
+        });
+        document.addEventListener("keydown", (e) => {
+          if (e.key === "Escape") closeMenu();
+        });
+        ["btn-restart", "new-game", "btn-test", "chk-autocheck"].forEach((id) => {
+          const el = document.getElementById(id);
+          if (!el) return;
+          el.addEventListener("click", () => {
+            closeMenu();
+          });
+        });
+      })();
 
       window.addEventListener('load', () => {
         customElements.whenDefined('playing-card').then(() => {

--- a/test/helpers/load-core.ts
+++ b/test/helpers/load-core.ts
@@ -32,10 +32,73 @@ export function loadSolverModule(contextSeed: Record<string, unknown>) {
   const filePath = path.resolve("src/core/solver.ts");
   return runCoreScript(filePath, contextSeed, "{ Simulator }") as {
     Simulator: new () => {
+      findSolvableDeck: () => any;
+      checkCurrentState: (state: any) => boolean;
       getNextMove: (state: any) => any;
       checkF: (state: any, card: any, fIdx: number) => boolean;
       findTabTarget: (state: any, card: any, ignoreIdx: number) => number;
       canSolve: (state: any, opts?: { limit?: number; noProgressLimit?: number }) => boolean;
+    };
+  };
+}
+
+export function loadPersistenceModule(contextSeed: Record<string, unknown>) {
+  const filePath = path.resolve("src/main.ts");
+  const source = fs.readFileSync(filePath, "utf8");
+  const match = source.match(
+    /\/\* --- \[Persistence\] --- \*\/([\s\S]*?)\/\* --- \[Core Modules\] --- \*\//
+  );
+  if (!match) {
+    throw new Error("Persistence block not found in src/main.ts");
+  }
+  const snippet = match[1];
+  const wrapped = `${snippet}\n;globalThis.__core_exports = { Persistence };`;
+
+  const script = new vm.Script(wrapped, { filename: "persistence-snippet.ts" });
+  const contextObject = {
+    updateMoveCounter: () => {},
+    ...contextSeed
+  } as Record<string, unknown>;
+  const context = vm.createContext(contextObject);
+  contextObject.globalThis = contextObject;
+  script.runInContext(context);
+  return contextObject.__core_exports as {
+    Persistence: {
+      saveCurrentProgress: () => void;
+      restoreFromLocal: () => boolean;
+    };
+  };
+}
+
+export function loadMainModule(contextSeed: Record<string, unknown>) {
+  const mainPath = path.resolve("src/main.ts");
+  const solverPath = path.resolve("src/core/solver.ts");
+  const rulesPath = path.resolve("src/core/rules.ts");
+  const source = [
+    fs.readFileSync(mainPath, "utf8"),
+    fs.readFileSync(solverPath, "utf8"),
+    fs.readFileSync(rulesPath, "utf8")
+  ].join("\n\n");
+  const script = new vm.Script(
+    `${source}\n;globalThis.__core_exports = { Controller, State, Persistence };`,
+    { filename: "main-with-core.ts" }
+  );
+  const contextObject = { ...contextSeed } as Record<string, unknown>;
+  const context = vm.createContext(contextObject);
+  contextObject.globalThis = contextObject;
+  script.runInContext(context);
+  return contextObject.__core_exports as {
+    Controller: {
+      startNewGame: () => Promise<void>;
+    };
+    State: {
+      current: any;
+      initial: any;
+      history: string[];
+    };
+    Persistence: {
+      saveCurrentProgress: () => void;
+      restoreFromLocal: () => boolean;
     };
   };
 }

--- a/test/new-game-integration.spec.ts
+++ b/test/new-game-integration.spec.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import { loadMainModule } from "./helpers/load-core";
+
+const ElementStub = function ElementStub() {};
+
+function createElement() {
+  return Object.assign(Object.create((ElementStub as any).prototype), {
+    textContent: "",
+    innerHTML: "",
+    checked: true,
+    disabled: false,
+    dataset: {} as Record<string, string>,
+    style: {} as Record<string, string>,
+    children: [] as any[],
+    onclick: null as any,
+    onchange: null as any,
+    oncontextmenu: null as any,
+    onpointerdown: null as any,
+    onpointerup: null as any,
+    onpointerleave: null as any,
+    onpointercancel: null as any,
+    addEventListener() {},
+    appendChild(node: any) {
+      this.children.push(node);
+      return node;
+    },
+    removeChild() {},
+    remove() {},
+    setAttribute() {},
+    getAttribute() {
+      return null;
+    },
+    querySelector() {
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    getBoundingClientRect() {
+      return {
+        left: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0
+      };
+    },
+    closest() {
+      return null;
+    }
+  });
+}
+
+function createDocumentStub() {
+  const store = new Map<string, ReturnType<typeof createElement>>();
+  const get = (id: string) => {
+    if (!store.has(id)) store.set(id, createElement());
+    return store.get(id)!;
+  };
+
+  [
+    "app-version",
+    "status-msg",
+    "stuck-warning",
+    "btn-undo",
+    "btn-restart",
+    "btn-hint",
+    "new-game",
+    "btn-test",
+    "btn-deal-again",
+    "chk-autocheck",
+    "win-overlay",
+    "stock",
+    "waste",
+    "moves-msg",
+    "foundation-0",
+    "foundation-1",
+    "foundation-2",
+    "foundation-3",
+    "tableau-0",
+    "tableau-1",
+    "tableau-2",
+    "tableau-3",
+    "tableau-4",
+    "tableau-5",
+    "tableau-6"
+  ].forEach(get);
+
+  return {
+    getElementById(id: string) {
+      return get(id);
+    },
+    createElement() {
+      return createElement();
+    },
+    querySelector() {
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    addEventListener() {}
+  };
+}
+
+function createMemoryStorage() {
+  const map = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return map.has(key) ? map.get(key)! : null;
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    }
+  };
+}
+
+function card(suit: number, rank: number, isOpen = true) {
+  return { suit, rank, color: suit % 2 === 0 ? 0 : 1, isOpen };
+}
+
+function boardState() {
+  return {
+    stock: [card(0, 1, false)],
+    waste: [card(1, 2, true)],
+    foundations: [[card(0, 1)], [], [], []],
+    tableau: [
+      [card(0, 7)],
+      [card(1, 6)],
+      [],
+      [],
+      [],
+      [],
+      []
+    ]
+  };
+}
+
+describe("new game integration", () => {
+  it("startNewGame initializes state and persists snapshot", async () => {
+    const document = createDocumentStub();
+    const localStorage = createMemoryStorage();
+    const windowStub = { addEventListener() {} };
+
+    const { Controller, State } = loadMainModule({
+      document,
+      localStorage,
+      location: { pathname: "/game/klondike.html" },
+      window: windowStub,
+      customElements: { whenDefined: async () => {} },
+      Element: ElementStub,
+      performance,
+      setTimeout,
+      clearTimeout,
+      Promise,
+      confirm: () => true,
+      console,
+      Math,
+      Date,
+      JSON
+    });
+
+    await Controller.startNewGame();
+
+    expect(State.current).not.toBeNull();
+    expect(State.initial).not.toBeNull();
+    expect(State.history).toHaveLength(0);
+    expect(localStorage.getItem("klondike:save:offline:v1")).not.toBeNull();
+  });
+
+  it("restores saved state on window load path", async () => {
+    const document = createDocumentStub();
+    const localStorage = createMemoryStorage();
+    let loadHandler: (() => void) | null = null;
+    const windowStub = {
+      addEventListener(type: string, handler: () => void) {
+        if (type === "load") loadHandler = handler;
+      }
+    };
+
+    const payload = {
+      schemaVersion: 1,
+      appVersion: "v20260304",
+      variant: "offline",
+      savedAt: new Date().toISOString(),
+      state: {
+        current: boardState(),
+        initial: boardState(),
+        history: [JSON.stringify(boardState())],
+        toggles: { autoCheck: false }
+      }
+    };
+    localStorage.setItem("klondike:save:offline:v1", JSON.stringify(payload));
+
+    const { State } = loadMainModule({
+      document,
+      localStorage,
+      location: { pathname: "/game/klondike.html" },
+      window: windowStub,
+      customElements: { whenDefined: async () => {} },
+      Element: ElementStub,
+      performance,
+      setTimeout,
+      clearTimeout,
+      Promise,
+      confirm: () => true,
+      console,
+      Math,
+      Date,
+      JSON
+    });
+
+    expect(loadHandler).not.toBeNull();
+    loadHandler!();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(State.current).not.toBeNull();
+    expect(State.history).toHaveLength(1);
+    expect(document.getElementById("chk-autocheck")?.checked).toBe(false);
+  });
+});

--- a/test/new-game-performance.spec.ts
+++ b/test/new-game-performance.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { loadSolverModule } from "./helpers/load-core";
+
+describe("new game performance", () => {
+  it("generates solvable new games within expected time budget", { timeout: 20000 }, () => {
+    const config = {
+      SOLVER_LIMIT_DEAL: 1000,
+      SOLVER_STALL_DEAL: 13,
+      SOLVER_LIMIT_CHECK: 1000,
+      SOLVER_STALL_CHECK: 200
+    };
+
+    const trials = Number(process.env.KLONDIKE_NEW_GAME_TRIALS ?? 10);
+    const maxTotalMs = Number(process.env.KLONDIKE_NEW_GAME_MAX_MS ?? 8000);
+
+    const { Simulator } = loadSolverModule({ Config: config });
+    const solver = new Simulator();
+
+    const started = performance.now();
+    for (let i = 0; i < trials; i++) {
+      const state = solver.findSolvableDeck();
+      expect(state.tableau).toHaveLength(7);
+      expect(state.foundations).toHaveLength(4);
+      expect(solver.checkCurrentState(state)).toBe(true);
+    }
+    const elapsed = performance.now() - started;
+
+    expect(elapsed).toBeLessThanOrEqual(maxTotalMs);
+  });
+});

--- a/test/persistence.spec.ts
+++ b/test/persistence.spec.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import { loadPersistenceModule } from "./helpers/load-core";
+
+function card(suit: number, rank: number, isOpen = true) {
+  return { suit, rank, color: suit % 2 === 0 ? 0 : 1, isOpen };
+}
+
+function boardState() {
+  return {
+    stock: [card(0, 1, false)],
+    waste: [card(1, 2, true)],
+    foundations: [[card(0, 1)], [], [], []],
+    tableau: [
+      [card(0, 7)],
+      [card(1, 6)],
+      [],
+      [],
+      [],
+      [],
+      []
+    ]
+  };
+}
+
+function createMemoryStorage() {
+  const map = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return map.has(key) ? map.get(key)! : null;
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    }
+  };
+}
+
+function createDocument(autoCheck = true) {
+  const appVersion = { textContent: "" };
+  const checkBox = { checked: autoCheck };
+  const status = { textContent: "", style: { opacity: "0" } };
+  const warning = { style: { opacity: "0" } };
+
+  return {
+    getElementById(id: string) {
+      if (id === "app-version") return appVersion;
+      if (id === "chk-autocheck") return checkBox;
+      if (id === "status-msg") return status;
+      if (id === "stuck-warning") return warning;
+      return null;
+    },
+    checkBox,
+    appVersion
+  };
+}
+
+describe("persistence", () => {
+  it("saves current progress with offline key", () => {
+    const localStorage = createMemoryStorage();
+    const document = createDocument(true);
+    const state = {
+      current: boardState(),
+      initial: boardState(),
+      history: [JSON.stringify(boardState())],
+      isAutoFinishing: false,
+      isAutoMoving: false,
+      isAnimating: false,
+      animatingCount: 0,
+      lastAnimationPromise: Promise.resolve(),
+      lastRevealPromise: Promise.resolve(),
+      lastAnimationEndAt: 0,
+      autoChainCount: 0
+    };
+
+    const { Persistence } = loadPersistenceModule({
+      Config: { APP_VERSION: "v20260304" },
+      State: state,
+      UI: { render: () => {} },
+      requestAutoCheck: () => {},
+      clearStatus: () => {},
+      updateButtons: () => {},
+      setLastMove: () => {},
+      document,
+      localStorage,
+      location: { pathname: "/game/klondike.html" }
+    });
+
+    Persistence.saveCurrentProgress();
+    const raw = localStorage.getItem("klondike:save:offline:v1");
+
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.state.history.length).toBe(1);
+  });
+
+  it("removes broken save payload during restore", () => {
+    const localStorage = createMemoryStorage();
+    localStorage.setItem("klondike:save:offline:v1", "{broken-json");
+
+    const { Persistence } = loadPersistenceModule({
+      Config: { APP_VERSION: "v20260304" },
+      State: {
+        current: null,
+        initial: null,
+        history: [],
+        isAutoFinishing: false,
+        isAutoMoving: false,
+        isAnimating: false,
+        animatingCount: 0,
+        lastAnimationPromise: Promise.resolve(),
+        lastRevealPromise: Promise.resolve(),
+        lastAnimationEndAt: 0,
+        autoChainCount: 0
+      },
+      UI: { render: () => {} },
+      requestAutoCheck: () => {},
+      clearStatus: () => {},
+      updateButtons: () => {},
+      setLastMove: () => {},
+      document: createDocument(),
+      localStorage,
+      location: { pathname: "/game/klondike.html" }
+    });
+
+    expect(Persistence.restoreFromLocal()).toBe(false);
+    expect(localStorage.getItem("klondike:save:offline:v1")).toBeNull();
+  });
+
+  it("does not restore offline save when running online variant", () => {
+    const localStorage = createMemoryStorage();
+    const payload = {
+      schemaVersion: 1,
+      appVersion: "v20260304",
+      variant: "offline",
+      savedAt: new Date().toISOString(),
+      state: {
+        current: boardState(),
+        initial: boardState(),
+        history: [JSON.stringify(boardState())],
+        toggles: { autoCheck: false }
+      }
+    };
+    localStorage.setItem("klondike:save:offline:v1", JSON.stringify(payload));
+
+    const state = {
+      current: null,
+      initial: null,
+      history: [],
+      isAutoFinishing: false,
+      isAutoMoving: false,
+      isAnimating: false,
+      animatingCount: 0,
+      lastAnimationPromise: Promise.resolve(),
+      lastRevealPromise: Promise.resolve(),
+      lastAnimationEndAt: 0,
+      autoChainCount: 0
+    };
+
+    const { Persistence } = loadPersistenceModule({
+      Config: { APP_VERSION: "v20260304" },
+      State: state,
+      UI: { render: () => {} },
+      requestAutoCheck: () => {},
+      clearStatus: () => {},
+      updateButtons: () => {},
+      setLastMove: () => {},
+      document: createDocument(),
+      localStorage,
+      location: { pathname: "/game/klondike-online.html" }
+    });
+
+    expect(Persistence.restoreFromLocal()).toBe(false);
+    expect(state.current).toBeNull();
+  });
+
+  it("migrates legacy offline key to primary key on restore", () => {
+    const localStorage = createMemoryStorage();
+    const payload = {
+      schemaVersion: 1,
+      appVersion: "v20260304",
+      variant: "offline",
+      savedAt: new Date().toISOString(),
+      state: {
+        current: boardState(),
+        initial: boardState(),
+        history: [JSON.stringify(boardState())],
+        toggles: { autoCheck: true }
+      }
+    };
+    localStorage.setItem("klondike-save", JSON.stringify(payload));
+
+    const state = {
+      current: null,
+      initial: null,
+      history: [],
+      isAutoFinishing: false,
+      isAutoMoving: false,
+      isAnimating: false,
+      animatingCount: 0,
+      lastAnimationPromise: Promise.resolve(),
+      lastRevealPromise: Promise.resolve(),
+      lastAnimationEndAt: 0,
+      autoChainCount: 0
+    };
+
+    const { Persistence } = loadPersistenceModule({
+      Config: { APP_VERSION: "v20260304" },
+      State: state,
+      UI: { render: () => {} },
+      requestAutoCheck: () => {},
+      clearStatus: () => {},
+      updateButtons: () => {},
+      setLastMove: () => {},
+      document: createDocument(),
+      localStorage,
+      location: { pathname: "/game/klondike.html" }
+    });
+
+    expect(Persistence.restoreFromLocal()).toBe(true);
+    expect(localStorage.getItem("klondike-save")).toBeNull();
+    expect(localStorage.getItem("klondike:save:offline:v1")).not.toBeNull();
+    expect(state.current).not.toBeNull();
+  });
+});


### PR DESCRIPTION
### 概要
ゲームUI/操作性と品質ゲートを強化しました。
主な変更は、`Moves: N`（手動手数）表示の導入、モバイル向けハンバーガーメニュー導入、`npm run build` へのテスト組み込み、そして localStorage / New Game の回帰テスト追加です。

### 変更内容
- `Moves` 表示を追加し、手動操作の手数を管理
- `Hint` は人間操作代行として `Moves` にカウント
- `Undo` 時に手数も巻き戻し
- `New Game` / `Restart` / `Test` で手数リセット
- 保存データに `manualMoveCount` と `moveCountHistory` を追加し、復元対応
- ヘッダー操作を整理
  - `Hint` を左、`Undo` を右の並びへ変更
  - `Restart` / `New Game` / `Solvability Check` / `Test` を三本メニュー（☰）へ移動
  - メニューは外側クリック・`Esc`・項目クリックで閉じる
- ビルド運用を強化
  - `npm run build` が `test:unit` を必ず先行実行
  - `build:html` と `check:all` を追加
- バージョン更新
  - `APP_VERSION` を `v20260305` に更新

### テスト追加
- `test/persistence.spec.ts`
  - 保存、破損データ安全リセット、offline/onlineキー分離、legacyキー移行
- `test/new-game-performance.spec.ts`
  - New Game 生成の時間予算と可解性チェック
- `test/new-game-integration.spec.ts`
  - `startNewGame()` の初期化/保存
  - 起動時（`window load`）復元パス

### 変更ファイル
- `package.json`
- `src/main.ts`
- `klondike-src.html`
- `klondike.html`
- `klondike-online.html`
- `test/helpers/load-core.ts`
- `test/persistence.spec.ts` (new)
- `test/new-game-performance.spec.ts` (new)
- `test/new-game-integration.spec.ts` (new)

### 確認観点
- `npm run build` でテスト + HTML生成が通ること
- `Moves` が手動操作/Hintで加算、Undoで巻き戻ること
- メニュー開閉挙動（外側クリック、Esc、項目クリックでclose）
- 保存復元後に手数とトグル状態が維持されること