### PR TITLE
feat: ヒント後の自動連鎖を手動フローに統一し、クリア時に Max Chain 表示を追加

### DIFF
--- a/klondike-online.html
+++ b/klondike-online.html
@@ -103,6 +103,7 @@
       }
       @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
       .win-msg { font-size: 40px; margin-bottom: 20px; font-family: "Times New Roman", serif; }
+      .win-stats { font-size: 18px; margin-bottom: 16px; font-weight: bold; }
       
       #stuck-warning {
         position: fixed; top: 15%; left: 50%; transform: translateX(-50%);
@@ -117,6 +118,7 @@
   <body oncontextmenu="return false;">
     <div id="win-overlay">
         <div class="win-msg">Congratulations</div>
+        <div id="win-stats" class="win-stats">Max Chain: 0</div>
         <button id="btn-deal-again">Deal Again</button>
     </div>
     
@@ -209,7 +211,8 @@
         lastAnimationEndAt: 0,
         lastRevealPromise: Promise.resolve(),
         lastMove: null,
-        autoChainCount: 0
+        autoChainCount: 0,
+        maxAutoChainCount: 0
       };
 
       document.getElementById("app-version").textContent = `${Config.APP_VERSION}`;
@@ -221,7 +224,12 @@
         State.manualMoveCount += 1;
         updateMoveCounter();
       }
+      function updateWinStats() {
+        const el = document.getElementById("win-stats");
+        if (el) el.textContent = `Max Chain: ${State.maxAutoChainCount}`;
+      }
       updateMoveCounter();
+      updateWinStats();
 
       /* --- [Persistence] --- */
       const Persistence = (() => {
@@ -349,6 +357,7 @@
               history: State.history,
               manualMoveCount: State.manualMoveCount,
               moveCountHistory: State.moveCountHistory,
+              maxAutoChainCount: State.maxAutoChainCount,
               toggles: readToggleState()
             }
           };
@@ -390,6 +399,8 @@
           else State.manualMoveCount = 0;
           if (isMoveCountHistory(s.moveCountHistory)) State.moveCountHistory = s.moveCountHistory;
           else State.moveCountHistory = Array(State.history.length).fill(0);
+          if (Number.isInteger(s.maxAutoChainCount) && s.maxAutoChainCount >= 0) State.maxAutoChainCount = s.maxAutoChainCount;
+          else State.maxAutoChainCount = 0;
           State.isAutoFinishing = false;
           State.isAutoMoving = false;
           State.isAnimating = false;
@@ -402,6 +413,7 @@
           setLastMove("deal", { animate: false });
           UI.render(State.current);
           updateMoveCounter();
+          updateWinStats();
           updateButtons();
           clearStatus();
           requestAutoCheck();
@@ -523,6 +535,7 @@
         State.history = []; 
         State.moveCountHistory = [];
         State.manualMoveCount = 0;
+        State.maxAutoChainCount = 0;
         State.isAutoFinishing = false;
         State.isAutoMoving = false;
         State.autoChainCount = 0;
@@ -530,6 +543,7 @@
         btnNew.disabled = false;
         setLastMove("deal", { animate: false });
         updateMoveCounter();
+        updateWinStats();
         UI.render(State.current); updateButtons(); requestAutoCheck(); // Init Check
         Persistence.saveCurrentProgress();
       }
@@ -555,12 +569,14 @@
         State.history = [];
         State.moveCountHistory = [];
         State.manualMoveCount = 0;
+        State.maxAutoChainCount = 0;
         State.isAutoFinishing = false;
         State.isAutoMoving = false;
         State.autoChainCount = 0;
         clearStatus();
         setLastMove("deal", { animate: false });
         updateMoveCounter();
+        updateWinStats();
         UI.render(State.current); updateButtons(); requestAutoCheck();
         checkVictoryCondition();
       }
@@ -573,12 +589,14 @@
             State.history = [];
             State.moveCountHistory = [];
             State.manualMoveCount = 0;
+            State.maxAutoChainCount = 0;
             State.isAutoFinishing = false;
             State.isAutoMoving = false;
             State.autoChainCount = 0;
             clearStatus();
             setLastMove("deal", { animate: false });
             updateMoveCounter();
+            updateWinStats();
             UI.render(State.current); updateButtons(); requestAutoCheck();
             Persistence.saveCurrentProgress();
         }
@@ -621,6 +639,7 @@
           if (moved) { 
               State.isAutoMoving = true;
               State.autoChainCount += 1;
+              State.maxAutoChainCount = Math.max(State.maxAutoChainCount, State.autoChainCount);
               setLastMove("auto", { foundationIdx, prevFoundationCard });
               UI.render(State.current);
               const endAt = State.lastAnimationEndAt;
@@ -706,7 +725,7 @@
         State.autoChainCount = 0;
         UI.render(State.current);
         const endAt = State.lastAnimationEndAt;
-        const afterReveal = () => { checkVictoryCondition(); requestAutoCheck(); };
+        const afterReveal = () => { triggerAutoFoundation(); requestAutoCheck(); };
         if (revealCard) scheduleReveal(revealCard, "auto", afterReveal, endAt);
         else waitForAnimationsThen(afterReveal);
       }
@@ -819,6 +838,7 @@
         const total = state.foundations.reduce((acc, f) => acc + f.length, 0);
         if (total === 52) { 
             State.isAutoMoving = false;
+            updateWinStats();
             document.getElementById("win-overlay").style.display = "flex"; 
             return; 
         }
@@ -849,6 +869,7 @@
         }
         if (moved) { 
           State.autoChainCount += 1;
+          State.maxAutoChainCount = Math.max(State.maxAutoChainCount, State.autoChainCount);
           setLastMove("auto", { foundationIdx, prevFoundationCard });
           UI.render(State.current); 
           waitForAnimationsThen(() => { setTimeout(autoDissolve, 80); });

--- a/klondike-src.html
+++ b/klondike-src.html
@@ -103,6 +103,7 @@
       }
       @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
       .win-msg { font-size: 40px; margin-bottom: 20px; font-family: "Times New Roman", serif; }
+      .win-stats { font-size: 18px; margin-bottom: 16px; font-weight: bold; }
       
       #stuck-warning {
         position: fixed; top: 15%; left: 50%; transform: translateX(-50%);
@@ -117,6 +118,7 @@
   <body oncontextmenu="return false;">
     <div id="win-overlay">
         <div class="win-msg">Congratulations</div>
+        <div id="win-stats" class="win-stats">Max Chain: 0</div>
         <button id="btn-deal-again">Deal Again</button>
     </div>
     

--- a/klondike.html
+++ b/klondike.html
@@ -115,6 +115,7 @@
       }
       @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
       .win-msg { font-size: 40px; margin-bottom: 20px; font-family: "Times New Roman", serif; }
+      .win-stats { font-size: 18px; margin-bottom: 16px; font-weight: bold; }
       
       #stuck-warning {
         position: fixed; top: 15%; left: 50%; transform: translateX(-50%);
@@ -129,6 +130,7 @@
   <body oncontextmenu="return false;">
     <div id="win-overlay">
         <div class="win-msg">Congratulations</div>
+        <div id="win-stats" class="win-stats">Max Chain: 0</div>
         <button id="btn-deal-again">Deal Again</button>
     </div>
     
@@ -221,7 +223,8 @@
         lastAnimationEndAt: 0,
         lastRevealPromise: Promise.resolve(),
         lastMove: null,
-        autoChainCount: 0
+        autoChainCount: 0,
+        maxAutoChainCount: 0
       };
 
       document.getElementById("app-version").textContent = `${Config.APP_VERSION}`;
@@ -233,7 +236,12 @@
         State.manualMoveCount += 1;
         updateMoveCounter();
       }
+      function updateWinStats() {
+        const el = document.getElementById("win-stats");
+        if (el) el.textContent = `Max Chain: ${State.maxAutoChainCount}`;
+      }
       updateMoveCounter();
+      updateWinStats();
 
       /* --- [Persistence] --- */
       const Persistence = (() => {
@@ -361,6 +369,7 @@
               history: State.history,
               manualMoveCount: State.manualMoveCount,
               moveCountHistory: State.moveCountHistory,
+              maxAutoChainCount: State.maxAutoChainCount,
               toggles: readToggleState()
             }
           };
@@ -402,6 +411,8 @@
           else State.manualMoveCount = 0;
           if (isMoveCountHistory(s.moveCountHistory)) State.moveCountHistory = s.moveCountHistory;
           else State.moveCountHistory = Array(State.history.length).fill(0);
+          if (Number.isInteger(s.maxAutoChainCount) && s.maxAutoChainCount >= 0) State.maxAutoChainCount = s.maxAutoChainCount;
+          else State.maxAutoChainCount = 0;
           State.isAutoFinishing = false;
           State.isAutoMoving = false;
           State.isAnimating = false;
@@ -414,6 +425,7 @@
           setLastMove("deal", { animate: false });
           UI.render(State.current);
           updateMoveCounter();
+          updateWinStats();
           updateButtons();
           clearStatus();
           requestAutoCheck();
@@ -535,6 +547,7 @@
         State.history = []; 
         State.moveCountHistory = [];
         State.manualMoveCount = 0;
+        State.maxAutoChainCount = 0;
         State.isAutoFinishing = false;
         State.isAutoMoving = false;
         State.autoChainCount = 0;
@@ -542,6 +555,7 @@
         btnNew.disabled = false;
         setLastMove("deal", { animate: false });
         updateMoveCounter();
+        updateWinStats();
         UI.render(State.current); updateButtons(); requestAutoCheck(); // Init Check
         Persistence.saveCurrentProgress();
       }
@@ -567,12 +581,14 @@
         State.history = [];
         State.moveCountHistory = [];
         State.manualMoveCount = 0;
+        State.maxAutoChainCount = 0;
         State.isAutoFinishing = false;
         State.isAutoMoving = false;
         State.autoChainCount = 0;
         clearStatus();
         setLastMove("deal", { animate: false });
         updateMoveCounter();
+        updateWinStats();
         UI.render(State.current); updateButtons(); requestAutoCheck();
         checkVictoryCondition();
       }
@@ -585,12 +601,14 @@
             State.history = [];
             State.moveCountHistory = [];
             State.manualMoveCount = 0;
+            State.maxAutoChainCount = 0;
             State.isAutoFinishing = false;
             State.isAutoMoving = false;
             State.autoChainCount = 0;
             clearStatus();
             setLastMove("deal", { animate: false });
             updateMoveCounter();
+            updateWinStats();
             UI.render(State.current); updateButtons(); requestAutoCheck();
             Persistence.saveCurrentProgress();
         }
@@ -633,6 +651,7 @@
           if (moved) { 
               State.isAutoMoving = true;
               State.autoChainCount += 1;
+              State.maxAutoChainCount = Math.max(State.maxAutoChainCount, State.autoChainCount);
               setLastMove("auto", { foundationIdx, prevFoundationCard });
               UI.render(State.current);
               const endAt = State.lastAnimationEndAt;
@@ -718,7 +737,7 @@
         State.autoChainCount = 0;
         UI.render(State.current);
         const endAt = State.lastAnimationEndAt;
-        const afterReveal = () => { checkVictoryCondition(); requestAutoCheck(); };
+        const afterReveal = () => { triggerAutoFoundation(); requestAutoCheck(); };
         if (revealCard) scheduleReveal(revealCard, "auto", afterReveal, endAt);
         else waitForAnimationsThen(afterReveal);
       }
@@ -831,6 +850,7 @@
         const total = state.foundations.reduce((acc, f) => acc + f.length, 0);
         if (total === 52) { 
             State.isAutoMoving = false;
+            updateWinStats();
             document.getElementById("win-overlay").style.display = "flex"; 
             return; 
         }
@@ -861,6 +881,7 @@
         }
         if (moved) { 
           State.autoChainCount += 1;
+          State.maxAutoChainCount = Math.max(State.maxAutoChainCount, State.autoChainCount);
           setLastMove("auto", { foundationIdx, prevFoundationCard });
           UI.render(State.current); 
           waitForAnimationsThen(() => { setTimeout(autoDissolve, 80); });

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,8 @@
         lastAnimationEndAt: 0,
         lastRevealPromise: Promise.resolve(),
         lastMove: null,
-        autoChainCount: 0
+        autoChainCount: 0,
+        maxAutoChainCount: 0
       };
 
       document.getElementById("app-version").textContent = `${Config.APP_VERSION}`;
@@ -49,7 +50,12 @@
         State.manualMoveCount += 1;
         updateMoveCounter();
       }
+      function updateWinStats() {
+        const el = document.getElementById("win-stats");
+        if (el) el.textContent = `Max Chain: ${State.maxAutoChainCount}`;
+      }
       updateMoveCounter();
+      updateWinStats();
 
       /* --- [Persistence] --- */
       const Persistence = (() => {
@@ -177,6 +183,7 @@
               history: State.history,
               manualMoveCount: State.manualMoveCount,
               moveCountHistory: State.moveCountHistory,
+              maxAutoChainCount: State.maxAutoChainCount,
               toggles: readToggleState()
             }
           };
@@ -218,6 +225,8 @@
           else State.manualMoveCount = 0;
           if (isMoveCountHistory(s.moveCountHistory)) State.moveCountHistory = s.moveCountHistory;
           else State.moveCountHistory = Array(State.history.length).fill(0);
+          if (Number.isInteger(s.maxAutoChainCount) && s.maxAutoChainCount >= 0) State.maxAutoChainCount = s.maxAutoChainCount;
+          else State.maxAutoChainCount = 0;
           State.isAutoFinishing = false;
           State.isAutoMoving = false;
           State.isAnimating = false;
@@ -230,6 +239,7 @@
           setLastMove("deal", { animate: false });
           UI.render(State.current);
           updateMoveCounter();
+          updateWinStats();
           updateButtons();
           clearStatus();
           requestAutoCheck();
@@ -351,6 +361,7 @@
         State.history = []; 
         State.moveCountHistory = [];
         State.manualMoveCount = 0;
+        State.maxAutoChainCount = 0;
         State.isAutoFinishing = false;
         State.isAutoMoving = false;
         State.autoChainCount = 0;
@@ -358,6 +369,7 @@
         btnNew.disabled = false;
         setLastMove("deal", { animate: false });
         updateMoveCounter();
+        updateWinStats();
         UI.render(State.current); updateButtons(); requestAutoCheck(); // Init Check
         Persistence.saveCurrentProgress();
       }
@@ -383,12 +395,14 @@
         State.history = [];
         State.moveCountHistory = [];
         State.manualMoveCount = 0;
+        State.maxAutoChainCount = 0;
         State.isAutoFinishing = false;
         State.isAutoMoving = false;
         State.autoChainCount = 0;
         clearStatus();
         setLastMove("deal", { animate: false });
         updateMoveCounter();
+        updateWinStats();
         UI.render(State.current); updateButtons(); requestAutoCheck();
         checkVictoryCondition();
       }
@@ -401,12 +415,14 @@
             State.history = [];
             State.moveCountHistory = [];
             State.manualMoveCount = 0;
+            State.maxAutoChainCount = 0;
             State.isAutoFinishing = false;
             State.isAutoMoving = false;
             State.autoChainCount = 0;
             clearStatus();
             setLastMove("deal", { animate: false });
             updateMoveCounter();
+            updateWinStats();
             UI.render(State.current); updateButtons(); requestAutoCheck();
             Persistence.saveCurrentProgress();
         }
@@ -449,6 +465,7 @@
           if (moved) { 
               State.isAutoMoving = true;
               State.autoChainCount += 1;
+              State.maxAutoChainCount = Math.max(State.maxAutoChainCount, State.autoChainCount);
               setLastMove("auto", { foundationIdx, prevFoundationCard });
               UI.render(State.current);
               const endAt = State.lastAnimationEndAt;
@@ -534,7 +551,7 @@
         State.autoChainCount = 0;
         UI.render(State.current);
         const endAt = State.lastAnimationEndAt;
-        const afterReveal = () => { checkVictoryCondition(); requestAutoCheck(); };
+        const afterReveal = () => { triggerAutoFoundation(); requestAutoCheck(); };
         if (revealCard) scheduleReveal(revealCard, "auto", afterReveal, endAt);
         else waitForAnimationsThen(afterReveal);
       }
@@ -647,6 +664,7 @@
         const total = state.foundations.reduce((acc, f) => acc + f.length, 0);
         if (total === 52) { 
             State.isAutoMoving = false;
+            updateWinStats();
             document.getElementById("win-overlay").style.display = "flex"; 
             return; 
         }
@@ -677,6 +695,7 @@
         }
         if (moved) { 
           State.autoChainCount += 1;
+          State.maxAutoChainCount = Math.max(State.maxAutoChainCount, State.autoChainCount);
           setLastMove("auto", { foundationIdx, prevFoundationCard });
           UI.render(State.current); 
           waitForAnimationsThen(() => { setTimeout(autoDissolve, 80); });

--- a/test/helpers/load-core.ts
+++ b/test/helpers/load-core.ts
@@ -57,6 +57,7 @@ export function loadPersistenceModule(contextSeed: Record<string, unknown>) {
   const script = new vm.Script(wrapped, { filename: "persistence-snippet.ts" });
   const contextObject = {
     updateMoveCounter: () => {},
+    updateWinStats: () => {},
     ...contextSeed
   } as Record<string, unknown>;
   const context = vm.createContext(contextObject);
@@ -90,6 +91,7 @@ export function loadMainModule(contextSeed: Record<string, unknown>) {
   return contextObject.__core_exports as {
     Controller: {
       startNewGame: () => Promise<void>;
+      hintMove: () => void;
     };
     State: {
       current: any;

--- a/test/new-game-integration.spec.ts
+++ b/test/new-game-integration.spec.ts
@@ -223,4 +223,43 @@ describe("new game integration", () => {
     expect(State.history).toHaveLength(1);
     expect(document.getElementById("chk-autocheck")?.checked).toBe(false);
   });
+
+  it("hint behaves like manual flow and continues auto foundation", async () => {
+    const document = createDocumentStub();
+    const localStorage = createMemoryStorage();
+    const windowStub = { addEventListener() {} };
+
+    const { Controller, State } = loadMainModule({
+      document,
+      localStorage,
+      location: { pathname: "/game/klondike.html" },
+      window: windowStub,
+      customElements: { whenDefined: async () => {} },
+      Element: ElementStub,
+      performance,
+      setTimeout,
+      clearTimeout,
+      Promise,
+      confirm: () => true,
+      console,
+      Math,
+      Date,
+      JSON
+    });
+
+    State.current = {
+      stock: [card(0, 1, false)],
+      waste: [],
+      foundations: [[], [], [], []],
+      tableau: [[], [], [], [], [], [], []]
+    };
+    State.initial = JSON.parse(JSON.stringify(State.current));
+    State.history = [];
+
+    Controller.hintMove();
+    await new Promise((resolve) => setTimeout(resolve, 950));
+
+    expect(State.current.foundations[0]).toHaveLength(1);
+    expect(State.current.waste).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
### 概要
ヒント実行後の挙動を手動操作と同等に揃え、連鎖演出の継続性を改善しました。
あわせて、1ゲーム内の最大自動連鎖数を記録し、クリアオーバーレイに表示する機能を追加しています。

### 変更内容
- `hintMove()` 後の処理を修正
  - `checkVictoryCondition()` 直行ではなく、`triggerAutoFoundation()` を経由するよう変更
  - ヒント後にも自動めくり/自動連鎖が継続する挙動に統一
- 最大連鎖数の状態管理を追加
  - `State.maxAutoChainCount` を追加
  - 自動連鎖進行時に `max(maxAutoChainCount, autoChainCount)` で更新
- 勝利画面に統計表示を追加
  - `win-overlay` 内に `Max Chain: N` を表示
  - `updateWinStats()` を追加して表示更新
- 保存/復元対応
  - `maxAutoChainCount` を snapshot に保存
  - 復元時に `maxAutoChainCount` を適用（不正値時は `0` フォールバック）
- 初期化タイミング対応
  - `New Game` / `Restart` / `Test` 開始時に `maxAutoChainCount` をリセット

### テスト
- integration テスト追加
  - `hint behaves like manual flow and continues auto foundation`
  - ヒント後に foundation へ自動遷移することを検証
- テストヘルパー更新
  - `hintMove` の型定義追加
  - `updateWinStats` の no-op スタブ追加（Persistence 単体ロード文脈）

### 変更ファイル
- `src/main.ts`
- `klondike-src.html`
- `klondike.html`（生成物）
- `klondike-online.html`（生成物）
- `test/new-game-integration.spec.ts`
- `test/helpers/load-core.ts`

### 期待される効果
- ヒント利用時の操作体験が手動操作と整合
- クリア時の達成感指標（最大連鎖数）の可視化
- 連鎖関連挙動の回帰検知強化