### PR TITLE
feat: クリアオーバーレイを再構成し、Hands表記とモバイルヘッダーの視認性を改善

### DIFF
--- a/klondike-online.html
+++ b/klondike-online.html
@@ -28,7 +28,7 @@
         body { min-height: 100dvh; }
       }
       header { padding: 15px 24px; display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 10px; max-width: 900px; margin: 0 auto; }
-      h1 { margin: 0; font-size: 18px; color: var(--accent); font-weight: normal; text-shadow: 1px 1px 2px black; text-align: center; display: flex; align-items: center; justify-content: center; gap: 6px; }
+      h1 { margin: 0; font-size: 18px; color: var(--accent); font-weight: normal; text-shadow: 1px 1px 2px black; text-align: center; display: flex; align-items: center; justify-content: center; gap: 6px; white-space: nowrap; width: 100%; }
       .app-version { font-size: 12px; opacity: 0.8; }
       .github-link { display: inline-flex; align-items: center; color: var(--accent); opacity: 0.9; }
       .github-link:hover { opacity: 1; }
@@ -62,7 +62,8 @@
       button:active { transform: translateY(1px); }
       button:disabled { opacity: 0.5; cursor: not-allowed; }
       
-      #status-msg { color: #ffff00; font-weight: bold; font-size: 14px; margin-right: 10px; text-shadow: 1px 1px 0 #000; min-width: 80px; text-align: right; }
+      #status-msg { color: #ffff00; font-weight: bold; font-size: 14px; margin-right: 6px; text-shadow: 1px 1px 0 #000; min-width: 0; text-align: right; white-space: nowrap; }
+      #moves-msg { font-weight: bold; font-size: 14px; text-shadow: 1px 1px 0 #000; white-space: nowrap; }
       
       .board { padding: 10px var(--board-pad) 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
       .legal { text-align: center; font-size: 12px; margin: 12px 0 16px; opacity: 0.85; border-top: 1px solid rgba(255,255,255,0.25); padding-top: 8px; display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: nowrap; }
@@ -79,8 +80,12 @@
           --card-h: calc(var(--card-w) * 1.4);
         }
         header { padding: 12px 10px; }
-        .controls { width: 100%; }
-        .menu { margin-left: auto; }
+        .controls { width: 100%; gap: 6px; flex-wrap: nowrap; justify-content: center; }
+        .controls button { padding: 5px 8px; font-size: 11px; }
+        .menu { margin-left: 0; }
+        .menu-btn { min-width: 34px; padding: 5px 8px; font-size: 15px; }
+        #status-msg { margin-right: 2px; font-size: 12px; }
+        #moves-msg { font-size: 12px; }
         .board { padding: 10px var(--board-pad); gap: 20px; }
       }
 
@@ -102,8 +107,22 @@
         color: white; animation: fadeIn 0.5s forwards;
       }
       @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
-      .win-msg { font-size: 40px; margin-bottom: 20px; font-family: "Times New Roman", serif; }
-      .win-stats { font-size: 18px; margin-bottom: 16px; font-weight: bold; }
+      .win-panel {
+        width: min(80vw, 520px);
+        margin: 0 auto 12px;
+        padding: 14px 18px;
+        text-align: center;
+        border-radius: 10px;
+        background: rgba(0, 50, 0, 0.88);
+        border: 1px solid rgba(255,255,255,0.28);
+        box-shadow: 0 8px 18px rgba(0,0,0,0.35);
+      }
+      .win-msg { font-size: clamp(34px, 8vw, 72px); margin: 0; font-family: "Times New Roman", serif; }
+      .win-stat { font-size: clamp(24px, 5vw, 48px); font-weight: bold; margin: 0; }
+      .win-title { background: transparent; border: 0; box-shadow: none; }
+      .win-action { background: transparent; border: 0; box-shadow: none; }
+      .win-action { margin-bottom: 0; }
+      .win-action button { font-size: clamp(16px, 3.8vw, 30px); padding: 10px 24px; }
       
       #stuck-warning {
         position: fixed; top: 15%; left: 50%; transform: translateX(-50%);
@@ -117,9 +136,10 @@
   </head>
   <body oncontextmenu="return false;">
     <div id="win-overlay">
-        <div class="win-msg">Congratulations</div>
-        <div id="win-stats" class="win-stats">Max Chain: 0</div>
-        <button id="btn-deal-again">Deal Again</button>
+        <div class="win-panel win-title"><div class="win-msg">Congratulations</div></div>
+        <div class="win-panel"><div id="win-hands" class="win-stat">Hands: 0</div></div>
+        <div class="win-panel"><div id="win-max-chain" class="win-stat">Max Chain: 0</div></div>
+        <div class="win-panel win-action"><button id="btn-deal-again">Deal Again</button></div>
     </div>
     
     <div id="stuck-warning">⚠️ Likely Stuck (Undo Recommended)</div>
@@ -131,7 +151,7 @@
       </h1>
       <div class="controls">
         <span id="status-msg"></span>
-        <span id="moves-msg">Moves: 0</span>
+        <span id="moves-msg">Hands: 0</span>
         <button id="btn-hint">Hint</button>
         <button id="btn-undo" disabled>Undo</button>
         <div class="menu">
@@ -218,15 +238,17 @@
       document.getElementById("app-version").textContent = `${Config.APP_VERSION}`;
       function updateMoveCounter() {
         const el = document.getElementById("moves-msg");
-        if (el) el.textContent = `Moves: ${State.manualMoveCount}`;
+        if (el) el.textContent = `Hands: ${State.manualMoveCount}`;
       }
       function incrementMoveCount() {
         State.manualMoveCount += 1;
         updateMoveCounter();
       }
       function updateWinStats() {
-        const el = document.getElementById("win-stats");
-        if (el) el.textContent = `Max Chain: ${State.maxAutoChainCount}`;
+        const handsEl = document.getElementById("win-hands");
+        if (handsEl) handsEl.textContent = `Hands: ${State.manualMoveCount}`;
+        const chainEl = document.getElementById("win-max-chain");
+        if (chainEl) chainEl.textContent = `Max Chain: ${State.maxAutoChainCount}`;
       }
       updateMoveCounter();
       updateWinStats();

--- a/klondike-src.html
+++ b/klondike-src.html
@@ -28,7 +28,7 @@
         body { min-height: 100dvh; }
       }
       header { padding: 15px 24px; display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 10px; max-width: 900px; margin: 0 auto; }
-      h1 { margin: 0; font-size: 18px; color: var(--accent); font-weight: normal; text-shadow: 1px 1px 2px black; text-align: center; display: flex; align-items: center; justify-content: center; gap: 6px; }
+      h1 { margin: 0; font-size: 18px; color: var(--accent); font-weight: normal; text-shadow: 1px 1px 2px black; text-align: center; display: flex; align-items: center; justify-content: center; gap: 6px; white-space: nowrap; width: 100%; }
       .app-version { font-size: 12px; opacity: 0.8; }
       .github-link { display: inline-flex; align-items: center; color: var(--accent); opacity: 0.9; }
       .github-link:hover { opacity: 1; }
@@ -62,7 +62,8 @@
       button:active { transform: translateY(1px); }
       button:disabled { opacity: 0.5; cursor: not-allowed; }
       
-      #status-msg { color: #ffff00; font-weight: bold; font-size: 14px; margin-right: 10px; text-shadow: 1px 1px 0 #000; min-width: 80px; text-align: right; }
+      #status-msg { color: #ffff00; font-weight: bold; font-size: 14px; margin-right: 6px; text-shadow: 1px 1px 0 #000; min-width: 0; text-align: right; white-space: nowrap; }
+      #moves-msg { font-weight: bold; font-size: 14px; text-shadow: 1px 1px 0 #000; white-space: nowrap; }
       
       .board { padding: 10px var(--board-pad) 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
       .legal { text-align: center; font-size: 12px; margin: 12px 0 16px; opacity: 0.85; border-top: 1px solid rgba(255,255,255,0.25); padding-top: 8px; display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: nowrap; }
@@ -79,8 +80,12 @@
           --card-h: calc(var(--card-w) * 1.4);
         }
         header { padding: 12px 10px; }
-        .controls { width: 100%; }
-        .menu { margin-left: auto; }
+        .controls { width: 100%; gap: 6px; flex-wrap: nowrap; justify-content: center; }
+        .controls button { padding: 5px 8px; font-size: 11px; }
+        .menu { margin-left: 0; }
+        .menu-btn { min-width: 34px; padding: 5px 8px; font-size: 15px; }
+        #status-msg { margin-right: 2px; font-size: 12px; }
+        #moves-msg { font-size: 12px; }
         .board { padding: 10px var(--board-pad); gap: 20px; }
       }
 
@@ -102,8 +107,22 @@
         color: white; animation: fadeIn 0.5s forwards;
       }
       @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
-      .win-msg { font-size: 40px; margin-bottom: 20px; font-family: "Times New Roman", serif; }
-      .win-stats { font-size: 18px; margin-bottom: 16px; font-weight: bold; }
+      .win-panel {
+        width: min(80vw, 520px);
+        margin: 0 auto 12px;
+        padding: 14px 18px;
+        text-align: center;
+        border-radius: 10px;
+        background: rgba(0, 50, 0, 0.88);
+        border: 1px solid rgba(255,255,255,0.28);
+        box-shadow: 0 8px 18px rgba(0,0,0,0.35);
+      }
+      .win-msg { font-size: clamp(34px, 8vw, 72px); margin: 0; font-family: "Times New Roman", serif; }
+      .win-stat { font-size: clamp(24px, 5vw, 48px); font-weight: bold; margin: 0; }
+      .win-title { background: transparent; border: 0; box-shadow: none; }
+      .win-action { background: transparent; border: 0; box-shadow: none; }
+      .win-action { margin-bottom: 0; }
+      .win-action button { font-size: clamp(16px, 3.8vw, 30px); padding: 10px 24px; }
       
       #stuck-warning {
         position: fixed; top: 15%; left: 50%; transform: translateX(-50%);
@@ -117,9 +136,10 @@
   </head>
   <body oncontextmenu="return false;">
     <div id="win-overlay">
-        <div class="win-msg">Congratulations</div>
-        <div id="win-stats" class="win-stats">Max Chain: 0</div>
-        <button id="btn-deal-again">Deal Again</button>
+        <div class="win-panel win-title"><div class="win-msg">Congratulations</div></div>
+        <div class="win-panel"><div id="win-hands" class="win-stat">Hands: 0</div></div>
+        <div class="win-panel"><div id="win-max-chain" class="win-stat">Max Chain: 0</div></div>
+        <div class="win-panel win-action"><button id="btn-deal-again">Deal Again</button></div>
     </div>
     
     <div id="stuck-warning">⚠️ Likely Stuck (Undo Recommended)</div>
@@ -131,7 +151,7 @@
       </h1>
       <div class="controls">
         <span id="status-msg"></span>
-        <span id="moves-msg">Moves: 0</span>
+        <span id="moves-msg">Hands: 0</span>
         <button id="btn-hint">Hint</button>
         <button id="btn-undo" disabled>Undo</button>
         <div class="menu">

--- a/klondike.html
+++ b/klondike.html
@@ -40,7 +40,7 @@
         body { min-height: 100dvh; }
       }
       header { padding: 15px 24px; display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 10px; max-width: 900px; margin: 0 auto; }
-      h1 { margin: 0; font-size: 18px; color: var(--accent); font-weight: normal; text-shadow: 1px 1px 2px black; text-align: center; display: flex; align-items: center; justify-content: center; gap: 6px; }
+      h1 { margin: 0; font-size: 18px; color: var(--accent); font-weight: normal; text-shadow: 1px 1px 2px black; text-align: center; display: flex; align-items: center; justify-content: center; gap: 6px; white-space: nowrap; width: 100%; }
       .app-version { font-size: 12px; opacity: 0.8; }
       .github-link { display: inline-flex; align-items: center; color: var(--accent); opacity: 0.9; }
       .github-link:hover { opacity: 1; }
@@ -74,7 +74,8 @@
       button:active { transform: translateY(1px); }
       button:disabled { opacity: 0.5; cursor: not-allowed; }
       
-      #status-msg { color: #ffff00; font-weight: bold; font-size: 14px; margin-right: 10px; text-shadow: 1px 1px 0 #000; min-width: 80px; text-align: right; }
+      #status-msg { color: #ffff00; font-weight: bold; font-size: 14px; margin-right: 6px; text-shadow: 1px 1px 0 #000; min-width: 0; text-align: right; white-space: nowrap; }
+      #moves-msg { font-weight: bold; font-size: 14px; text-shadow: 1px 1px 0 #000; white-space: nowrap; }
       
       .board { padding: 10px var(--board-pad) 40px; display: grid; gap: 40px; max-width: 900px; margin: 0 auto; transition: gap 0.3s; }
       .legal { text-align: center; font-size: 12px; margin: 12px 0 16px; opacity: 0.85; border-top: 1px solid rgba(255,255,255,0.25); padding-top: 8px; display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: nowrap; }
@@ -91,8 +92,12 @@
           --card-h: calc(var(--card-w) * 1.4);
         }
         header { padding: 12px 10px; }
-        .controls { width: 100%; }
-        .menu { margin-left: auto; }
+        .controls { width: 100%; gap: 6px; flex-wrap: nowrap; justify-content: center; }
+        .controls button { padding: 5px 8px; font-size: 11px; }
+        .menu { margin-left: 0; }
+        .menu-btn { min-width: 34px; padding: 5px 8px; font-size: 15px; }
+        #status-msg { margin-right: 2px; font-size: 12px; }
+        #moves-msg { font-size: 12px; }
         .board { padding: 10px var(--board-pad); gap: 20px; }
       }
 
@@ -114,8 +119,22 @@
         color: white; animation: fadeIn 0.5s forwards;
       }
       @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
-      .win-msg { font-size: 40px; margin-bottom: 20px; font-family: "Times New Roman", serif; }
-      .win-stats { font-size: 18px; margin-bottom: 16px; font-weight: bold; }
+      .win-panel {
+        width: min(80vw, 520px);
+        margin: 0 auto 12px;
+        padding: 14px 18px;
+        text-align: center;
+        border-radius: 10px;
+        background: rgba(0, 50, 0, 0.88);
+        border: 1px solid rgba(255,255,255,0.28);
+        box-shadow: 0 8px 18px rgba(0,0,0,0.35);
+      }
+      .win-msg { font-size: clamp(34px, 8vw, 72px); margin: 0; font-family: "Times New Roman", serif; }
+      .win-stat { font-size: clamp(24px, 5vw, 48px); font-weight: bold; margin: 0; }
+      .win-title { background: transparent; border: 0; box-shadow: none; }
+      .win-action { background: transparent; border: 0; box-shadow: none; }
+      .win-action { margin-bottom: 0; }
+      .win-action button { font-size: clamp(16px, 3.8vw, 30px); padding: 10px 24px; }
       
       #stuck-warning {
         position: fixed; top: 15%; left: 50%; transform: translateX(-50%);
@@ -129,9 +148,10 @@
   </head>
   <body oncontextmenu="return false;">
     <div id="win-overlay">
-        <div class="win-msg">Congratulations</div>
-        <div id="win-stats" class="win-stats">Max Chain: 0</div>
-        <button id="btn-deal-again">Deal Again</button>
+        <div class="win-panel win-title"><div class="win-msg">Congratulations</div></div>
+        <div class="win-panel"><div id="win-hands" class="win-stat">Hands: 0</div></div>
+        <div class="win-panel"><div id="win-max-chain" class="win-stat">Max Chain: 0</div></div>
+        <div class="win-panel win-action"><button id="btn-deal-again">Deal Again</button></div>
     </div>
     
     <div id="stuck-warning">⚠️ Likely Stuck (Undo Recommended)</div>
@@ -143,7 +163,7 @@
       </h1>
       <div class="controls">
         <span id="status-msg"></span>
-        <span id="moves-msg">Moves: 0</span>
+        <span id="moves-msg">Hands: 0</span>
         <button id="btn-hint">Hint</button>
         <button id="btn-undo" disabled>Undo</button>
         <div class="menu">
@@ -230,15 +250,17 @@
       document.getElementById("app-version").textContent = `${Config.APP_VERSION}`;
       function updateMoveCounter() {
         const el = document.getElementById("moves-msg");
-        if (el) el.textContent = `Moves: ${State.manualMoveCount}`;
+        if (el) el.textContent = `Hands: ${State.manualMoveCount}`;
       }
       function incrementMoveCount() {
         State.manualMoveCount += 1;
         updateMoveCounter();
       }
       function updateWinStats() {
-        const el = document.getElementById("win-stats");
-        if (el) el.textContent = `Max Chain: ${State.maxAutoChainCount}`;
+        const handsEl = document.getElementById("win-hands");
+        if (handsEl) handsEl.textContent = `Hands: ${State.manualMoveCount}`;
+        const chainEl = document.getElementById("win-max-chain");
+        if (chainEl) chainEl.textContent = `Max Chain: ${State.maxAutoChainCount}`;
       }
       updateMoveCounter();
       updateWinStats();

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,15 +44,17 @@
       document.getElementById("app-version").textContent = `${Config.APP_VERSION}`;
       function updateMoveCounter() {
         const el = document.getElementById("moves-msg");
-        if (el) el.textContent = `Moves: ${State.manualMoveCount}`;
+        if (el) el.textContent = `Hands: ${State.manualMoveCount}`;
       }
       function incrementMoveCount() {
         State.manualMoveCount += 1;
         updateMoveCounter();
       }
       function updateWinStats() {
-        const el = document.getElementById("win-stats");
-        if (el) el.textContent = `Max Chain: ${State.maxAutoChainCount}`;
+        const handsEl = document.getElementById("win-hands");
+        if (handsEl) handsEl.textContent = `Hands: ${State.manualMoveCount}`;
+        const chainEl = document.getElementById("win-max-chain");
+        if (chainEl) chainEl.textContent = `Max Chain: ${State.maxAutoChainCount}`;
       }
       updateMoveCounter();
       updateWinStats();


### PR DESCRIPTION
### 概要
クリア時UIを見直し、`Hands` / `Max Chain` を独立表示する構成へ変更しました。 同時に、ヘッダーの表記を `Moves` から `Hands` に統一し、iPhone SE3 など狭幅端末でのレイアウト崩れを抑える調整を実施しています。

### 変更内容
- クリアオーバーレイ (`win-overlay`) の再構成
  - `Congratulations` / `Hands` / `Max Chain` / `Deal Again` を縦並びで表示
  - `Hands` と `Max Chain` は別要素（`#win-hands`, `#win-max-chain`）に分離
  - `Congratulations` と `Deal Again` は枠なし（透明パネル）
- 勝利統計の更新処理を修正
  - `updateWinStats()` で `#win-hands` と `#win-max-chain` を個別更新
- 文言統一
  - ヘッダー手数表示を `Moves` から `Hands` へ変更
- モバイルレイアウト改善
  - `h1` を1行維持（`white-space: nowrap`, `width: 100%`）
  - 狭幅時の `.controls` を折り返し抑制し、gap/ボタンサイズを調整
  - `status` / `hands` のフォントと余白をモバイル向けに最適化

### 変更ファイル
- `src/main.ts`
- `klondike-src.html`
- `klondike.html`（生成物）
- `klondike-online.html`（生成物）

### 確認観点
- クリア時に `Hands` / `Max Chain` の数値が表示されること
- `Congratulations` と `Deal Again` が枠なしで表示されること
- iPhone SE3 相当幅でヘッダーが崩れにくいこと
- 通常プレイ中のヘッダー手数表示が `Hands: N` であること