### PR TITLE
fix: iPhone向けに勝利画面のコピー機能を強化し、統計付きコピーに対応

### DIFF
--- a/klondike-online.html
+++ b/klondike-online.html
@@ -139,6 +139,24 @@
         font-size: clamp(13px, 2.5vw, 20px);
         padding: 6px 14px;
       }
+      .win-startkey-fallback {
+        margin-top: 10px;
+        display: grid;
+        gap: 8px;
+        justify-items: center;
+      }
+      .win-startkey-fallback[hidden] { display: none; }
+      .win-startkey-input {
+        width: min(90%, 460px);
+        font-size: clamp(14px, 2.8vw, 22px);
+        padding: 6px 10px;
+        text-align: center;
+        font-family: "Courier New", monospace;
+      }
+      .win-startkey-help {
+        font-size: clamp(12px, 2.4vw, 16px);
+        opacity: 0.95;
+      }
       .win-title { background: transparent; border: 0; box-shadow: none; }
       .win-action { background: transparent; border: 0; box-shadow: none; }
       .win-action { margin-bottom: 0; }
@@ -164,6 +182,11 @@
             <span class="win-startkey-label">StartKey:</span>
             <span id="win-startkey-value" class="win-startkey-value">-</span>
             <button id="btn-copy-startkey" class="win-copy-btn" type="button">Copy</button>
+          </div>
+          <div id="win-startkey-fallback" class="win-startkey-fallback" hidden>
+            <input id="win-startkey-input" class="win-startkey-input" type="text" readonly value="" />
+            <button id="btn-select-startkey" class="win-copy-btn" type="button">Select</button>
+            <div class="win-startkey-help">If copy fails on iPhone, long-press the text above and copy.</div>
           </div>
         </div>
         <div class="win-panel win-action"><button id="btn-deal-again">Deal Again</button></div>
@@ -300,6 +323,7 @@
         setLastMove("deal", { animate: false });
         updateMoveCounter();
         updateWinStats();
+        hideStartKeyFallback();
         UI.render(State.current);
         updateButtons();
         requestAutoCheck();
@@ -317,6 +341,61 @@
           } else {
             startKeyEl.textContent = "-";
           }
+        }
+        const startKeyInput = document.getElementById("win-startkey-input");
+        if (startKeyInput) {
+          startKeyInput.value = buildWinCopyText();
+        }
+      }
+      function buildWinCopyText() {
+        const key = State.startSeed
+          ? makeStartKey(State.startSeed, State.startAttemptIndex || 0)
+          : "-";
+        return `StartKey: ${key} | Hands: ${State.manualMoveCount} | Max Chain: ${State.maxAutoChainCount}`;
+      }
+      function hideStartKeyFallback() {
+        const fallback = document.getElementById("win-startkey-fallback");
+        if (fallback) fallback.hidden = true;
+      }
+      function selectStartKeyInput() {
+        const input = document.getElementById("win-startkey-input");
+        if (!input) return false;
+        input.focus();
+        input.select();
+        if (typeof input.setSelectionRange === "function") {
+          input.setSelectionRange(0, input.value.length);
+        }
+        return true;
+      }
+      function showStartKeyFallback(key) {
+        const fallback = document.getElementById("win-startkey-fallback");
+        const input = document.getElementById("win-startkey-input");
+        if (!fallback || !input) {
+          prompt("Copy StartKey", key);
+          return;
+        }
+        input.value = key;
+        fallback.hidden = false;
+        selectStartKeyInput();
+        showStatus("Long-press StartKey to copy", "#ffff00");
+      }
+      function tryLegacyCopy(text) {
+        try {
+          const area = document.createElement("textarea");
+          area.value = text;
+          area.setAttribute("readonly", "");
+          area.style.position = "fixed";
+          area.style.top = "-9999px";
+          area.style.left = "-9999px";
+          document.body.appendChild(area);
+          area.focus();
+          area.select();
+          if (typeof area.setSelectionRange === "function") area.setSelectionRange(0, area.value.length);
+          const ok = !!(document.execCommand && document.execCommand("copy"));
+          document.body.removeChild(area);
+          return ok;
+        } catch (e) {
+          return false;
         }
       }
       updateMoveCounter();
@@ -1233,6 +1312,7 @@
       document.getElementById("btn-test").onclick = Controller.startTestGame;
       document.getElementById("btn-deal-again").onclick = () => {
         document.getElementById("win-overlay").style.display = "none";
+        hideStartKeyFallback();
         Controller.startNewGame();
       };
       document.getElementById("btn-show-startkey").onclick = () => {
@@ -1244,19 +1324,26 @@
         prompt("StartKey", key);
       };
       document.getElementById("btn-copy-startkey").onclick = async () => {
-        if (!State.startSeed) {
-          alert("StartKey is not available for this board.");
-          return;
-        }
-        const key = makeStartKey(State.startSeed, State.startAttemptIndex || 0);
+        const text = buildWinCopyText();
+        hideStartKeyFallback();
         try {
           if (navigator.clipboard && navigator.clipboard.writeText) {
-            await navigator.clipboard.writeText(key);
+            await navigator.clipboard.writeText(text);
             showStatus("StartKey Copied", "#00ff00");
             return;
           }
         } catch (e) {}
-        prompt("Copy StartKey", key);
+        if (tryLegacyCopy(text)) {
+          showStatus("StartKey Copied", "#00ff00");
+          return;
+        }
+        showStartKeyFallback(text);
+      };
+      document.getElementById("btn-select-startkey").onclick = () => {
+        if (selectStartKeyInput()) showStatus("StartKey selected", "#ffff00");
+      };
+      document.getElementById("win-startkey-input").onclick = () => {
+        selectStartKeyInput();
       };
       document.getElementById("btn-load-startkey").onclick = () => {
         const raw = prompt("Enter StartKey (SEED-ATTEMPT)", "");

--- a/klondike-src.html
+++ b/klondike-src.html
@@ -139,6 +139,24 @@
         font-size: clamp(13px, 2.5vw, 20px);
         padding: 6px 14px;
       }
+      .win-startkey-fallback {
+        margin-top: 10px;
+        display: grid;
+        gap: 8px;
+        justify-items: center;
+      }
+      .win-startkey-fallback[hidden] { display: none; }
+      .win-startkey-input {
+        width: min(90%, 460px);
+        font-size: clamp(14px, 2.8vw, 22px);
+        padding: 6px 10px;
+        text-align: center;
+        font-family: "Courier New", monospace;
+      }
+      .win-startkey-help {
+        font-size: clamp(12px, 2.4vw, 16px);
+        opacity: 0.95;
+      }
       .win-title { background: transparent; border: 0; box-shadow: none; }
       .win-action { background: transparent; border: 0; box-shadow: none; }
       .win-action { margin-bottom: 0; }
@@ -164,6 +182,11 @@
             <span class="win-startkey-label">StartKey:</span>
             <span id="win-startkey-value" class="win-startkey-value">-</span>
             <button id="btn-copy-startkey" class="win-copy-btn" type="button">Copy</button>
+          </div>
+          <div id="win-startkey-fallback" class="win-startkey-fallback" hidden>
+            <input id="win-startkey-input" class="win-startkey-input" type="text" readonly value="" />
+            <button id="btn-select-startkey" class="win-copy-btn" type="button">Select</button>
+            <div class="win-startkey-help">If copy fails on iPhone, long-press the text above and copy.</div>
           </div>
         </div>
         <div class="win-panel win-action"><button id="btn-deal-again">Deal Again</button></div>

--- a/klondike.html
+++ b/klondike.html
@@ -151,6 +151,24 @@
         font-size: clamp(13px, 2.5vw, 20px);
         padding: 6px 14px;
       }
+      .win-startkey-fallback {
+        margin-top: 10px;
+        display: grid;
+        gap: 8px;
+        justify-items: center;
+      }
+      .win-startkey-fallback[hidden] { display: none; }
+      .win-startkey-input {
+        width: min(90%, 460px);
+        font-size: clamp(14px, 2.8vw, 22px);
+        padding: 6px 10px;
+        text-align: center;
+        font-family: "Courier New", monospace;
+      }
+      .win-startkey-help {
+        font-size: clamp(12px, 2.4vw, 16px);
+        opacity: 0.95;
+      }
       .win-title { background: transparent; border: 0; box-shadow: none; }
       .win-action { background: transparent; border: 0; box-shadow: none; }
       .win-action { margin-bottom: 0; }
@@ -176,6 +194,11 @@
             <span class="win-startkey-label">StartKey:</span>
             <span id="win-startkey-value" class="win-startkey-value">-</span>
             <button id="btn-copy-startkey" class="win-copy-btn" type="button">Copy</button>
+          </div>
+          <div id="win-startkey-fallback" class="win-startkey-fallback" hidden>
+            <input id="win-startkey-input" class="win-startkey-input" type="text" readonly value="" />
+            <button id="btn-select-startkey" class="win-copy-btn" type="button">Select</button>
+            <div class="win-startkey-help">If copy fails on iPhone, long-press the text above and copy.</div>
           </div>
         </div>
         <div class="win-panel win-action"><button id="btn-deal-again">Deal Again</button></div>
@@ -312,6 +335,7 @@
         setLastMove("deal", { animate: false });
         updateMoveCounter();
         updateWinStats();
+        hideStartKeyFallback();
         UI.render(State.current);
         updateButtons();
         requestAutoCheck();
@@ -329,6 +353,61 @@
           } else {
             startKeyEl.textContent = "-";
           }
+        }
+        const startKeyInput = document.getElementById("win-startkey-input");
+        if (startKeyInput) {
+          startKeyInput.value = buildWinCopyText();
+        }
+      }
+      function buildWinCopyText() {
+        const key = State.startSeed
+          ? makeStartKey(State.startSeed, State.startAttemptIndex || 0)
+          : "-";
+        return `StartKey: ${key} | Hands: ${State.manualMoveCount} | Max Chain: ${State.maxAutoChainCount}`;
+      }
+      function hideStartKeyFallback() {
+        const fallback = document.getElementById("win-startkey-fallback");
+        if (fallback) fallback.hidden = true;
+      }
+      function selectStartKeyInput() {
+        const input = document.getElementById("win-startkey-input");
+        if (!input) return false;
+        input.focus();
+        input.select();
+        if (typeof input.setSelectionRange === "function") {
+          input.setSelectionRange(0, input.value.length);
+        }
+        return true;
+      }
+      function showStartKeyFallback(key) {
+        const fallback = document.getElementById("win-startkey-fallback");
+        const input = document.getElementById("win-startkey-input");
+        if (!fallback || !input) {
+          prompt("Copy StartKey", key);
+          return;
+        }
+        input.value = key;
+        fallback.hidden = false;
+        selectStartKeyInput();
+        showStatus("Long-press StartKey to copy", "#ffff00");
+      }
+      function tryLegacyCopy(text) {
+        try {
+          const area = document.createElement("textarea");
+          area.value = text;
+          area.setAttribute("readonly", "");
+          area.style.position = "fixed";
+          area.style.top = "-9999px";
+          area.style.left = "-9999px";
+          document.body.appendChild(area);
+          area.focus();
+          area.select();
+          if (typeof area.setSelectionRange === "function") area.setSelectionRange(0, area.value.length);
+          const ok = !!(document.execCommand && document.execCommand("copy"));
+          document.body.removeChild(area);
+          return ok;
+        } catch (e) {
+          return false;
         }
       }
       updateMoveCounter();
@@ -1245,6 +1324,7 @@
       document.getElementById("btn-test").onclick = Controller.startTestGame;
       document.getElementById("btn-deal-again").onclick = () => {
         document.getElementById("win-overlay").style.display = "none";
+        hideStartKeyFallback();
         Controller.startNewGame();
       };
       document.getElementById("btn-show-startkey").onclick = () => {
@@ -1256,19 +1336,26 @@
         prompt("StartKey", key);
       };
       document.getElementById("btn-copy-startkey").onclick = async () => {
-        if (!State.startSeed) {
-          alert("StartKey is not available for this board.");
-          return;
-        }
-        const key = makeStartKey(State.startSeed, State.startAttemptIndex || 0);
+        const text = buildWinCopyText();
+        hideStartKeyFallback();
         try {
           if (navigator.clipboard && navigator.clipboard.writeText) {
-            await navigator.clipboard.writeText(key);
+            await navigator.clipboard.writeText(text);
             showStatus("StartKey Copied", "#00ff00");
             return;
           }
         } catch (e) {}
-        prompt("Copy StartKey", key);
+        if (tryLegacyCopy(text)) {
+          showStatus("StartKey Copied", "#00ff00");
+          return;
+        }
+        showStartKeyFallback(text);
+      };
+      document.getElementById("btn-select-startkey").onclick = () => {
+        if (selectStartKeyInput()) showStatus("StartKey selected", "#ffff00");
+      };
+      document.getElementById("win-startkey-input").onclick = () => {
+        selectStartKeyInput();
       };
       document.getElementById("btn-load-startkey").onclick = () => {
         const raw = prompt("Enter StartKey (SEED-ATTEMPT)", "");

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,6 +77,7 @@
         setLastMove("deal", { animate: false });
         updateMoveCounter();
         updateWinStats();
+        hideStartKeyFallback();
         UI.render(State.current);
         updateButtons();
         requestAutoCheck();
@@ -94,6 +95,61 @@
           } else {
             startKeyEl.textContent = "-";
           }
+        }
+        const startKeyInput = document.getElementById("win-startkey-input");
+        if (startKeyInput) {
+          startKeyInput.value = buildWinCopyText();
+        }
+      }
+      function buildWinCopyText() {
+        const key = State.startSeed
+          ? makeStartKey(State.startSeed, State.startAttemptIndex || 0)
+          : "-";
+        return `StartKey: ${key} | Hands: ${State.manualMoveCount} | Max Chain: ${State.maxAutoChainCount}`;
+      }
+      function hideStartKeyFallback() {
+        const fallback = document.getElementById("win-startkey-fallback");
+        if (fallback) fallback.hidden = true;
+      }
+      function selectStartKeyInput() {
+        const input = document.getElementById("win-startkey-input");
+        if (!input) return false;
+        input.focus();
+        input.select();
+        if (typeof input.setSelectionRange === "function") {
+          input.setSelectionRange(0, input.value.length);
+        }
+        return true;
+      }
+      function showStartKeyFallback(key) {
+        const fallback = document.getElementById("win-startkey-fallback");
+        const input = document.getElementById("win-startkey-input");
+        if (!fallback || !input) {
+          prompt("Copy StartKey", key);
+          return;
+        }
+        input.value = key;
+        fallback.hidden = false;
+        selectStartKeyInput();
+        showStatus("Long-press StartKey to copy", "#ffff00");
+      }
+      function tryLegacyCopy(text) {
+        try {
+          const area = document.createElement("textarea");
+          area.value = text;
+          area.setAttribute("readonly", "");
+          area.style.position = "fixed";
+          area.style.top = "-9999px";
+          area.style.left = "-9999px";
+          document.body.appendChild(area);
+          area.focus();
+          area.select();
+          if (typeof area.setSelectionRange === "function") area.setSelectionRange(0, area.value.length);
+          const ok = !!(document.execCommand && document.execCommand("copy"));
+          document.body.removeChild(area);
+          return ok;
+        } catch (e) {
+          return false;
         }
       }
       updateMoveCounter();
@@ -1010,6 +1066,7 @@
       document.getElementById("btn-test").onclick = Controller.startTestGame;
       document.getElementById("btn-deal-again").onclick = () => {
         document.getElementById("win-overlay").style.display = "none";
+        hideStartKeyFallback();
         Controller.startNewGame();
       };
       document.getElementById("btn-show-startkey").onclick = () => {
@@ -1021,19 +1078,26 @@
         prompt("StartKey", key);
       };
       document.getElementById("btn-copy-startkey").onclick = async () => {
-        if (!State.startSeed) {
-          alert("StartKey is not available for this board.");
-          return;
-        }
-        const key = makeStartKey(State.startSeed, State.startAttemptIndex || 0);
+        const text = buildWinCopyText();
+        hideStartKeyFallback();
         try {
           if (navigator.clipboard && navigator.clipboard.writeText) {
-            await navigator.clipboard.writeText(key);
+            await navigator.clipboard.writeText(text);
             showStatus("StartKey Copied", "#00ff00");
             return;
           }
         } catch (e) {}
-        prompt("Copy StartKey", key);
+        if (tryLegacyCopy(text)) {
+          showStatus("StartKey Copied", "#00ff00");
+          return;
+        }
+        showStartKeyFallback(text);
+      };
+      document.getElementById("btn-select-startkey").onclick = () => {
+        if (selectStartKeyInput()) showStatus("StartKey selected", "#ffff00");
+      };
+      document.getElementById("win-startkey-input").onclick = () => {
+        selectStartKeyInput();
       };
       document.getElementById("btn-load-startkey").onclick = () => {
         const raw = prompt("Enter StartKey (SEED-ATTEMPT)", "");


### PR DESCRIPTION
### 概要
iPhone（特に Safari / iOS）で `Copy` が失敗するケースに対応するため、勝利画面の StartKey コピー機能にフォールバック導線を追加しました。 あわせて、コピー内容を `StartKey` のみから `StartKey + Hands + Max Chain` に拡張しています。

### 変更内容

1. コピー失敗時のフォールバックUI追加
- `klondike-src.html`（および生成物 `klondike.html` / `klondike-online.html`）に以下を追加
  - `#win-startkey-fallback`（初期は hidden）
  - `#win-startkey-input`（readonly、選択しやすい表示欄）
  - `#btn-select-startkey`（選択補助）
  - iPhone向け案内文（長押しコピー）

2. コピー内容を拡張
- `src/main.ts`
  - `buildWinCopyText()` を追加
  - コピー文字列を以下の1行に統一:
    - `StartKey: ... | Hands: ... | Max Chain: ...`

3. コピー処理の多段フォールバック化
- `btn-copy-startkey` の処理を強化
  - 1段目: `navigator.clipboard.writeText(...)`
  - 2段目: `document.execCommand("copy")`（legacy）
  - 3段目: フォールバックUI表示 + 手動コピー誘導

4. UI状態管理の改善
- `applyStartState()` / `Deal Again` 時に `hideStartKeyFallback()` を実行して表示をリセット
- `updateWinStats()` 時にフォールバック入力欄の内容も同期更新
- `btn-select-startkey` と入力欄クリックでテキスト選択を補助

### 影響範囲
- `src/main.ts`
- `klondike-src.html`
- 生成ファイル: `klondike.html`, `klondike-online.html`

### 期待効果
- iPhoneでクリップボードAPIが失敗しても、勝利画面から確実に手動コピーできる
- 共有/記録時に `StartKey` だけでなく `Hands` と `Max Chain` も同時に持ち出せる